### PR TITLE
Fix some missed renamings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Barium Build Script
+name: C2ME Build Script
 
 on:
   push:
@@ -25,13 +25,13 @@ jobs:
         path: ~/.gradle
         key: ${{ runner.os }}-maven-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-java-11
         
-    - name: Build Barium
+    - name: Build C2ME
       run: |
         ./gradlew clean build
         
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: Barrium
+        name: C2ME
         path: ./build/libs/C2ME-fabric-0.1-SNAPSHOT-all.jar
       

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,5 @@ yarn_mappings=1.16.5+build.4
 loader_version=0.11.1
 # Mod Properties
 mod_version=0.1-SNAPSHOT
-maven_group=org.yatopiamc.barium
-archives_base_name=barium-fabric
-
+maven_group=org.yatopiamc.c2me
+archives_base_name=C2ME-fabric


### PR DESCRIPTION
also fixes compiled jars being named `barium`, rather than `C2ME`, causing github actions to not recognize the jars