### PR TITLE
Bump loom-quiltflower-mini to 1.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'fabric-loom' version '0.10-SNAPSHOT'
-    id 'io.github.juuxel.loom-quiltflower-mini' version '1.1.0'
+    id 'io.github.juuxel.loom-quiltflower-mini' version '1.2.1'
     id 'maven-publish'
     id 'com.github.johnrengelman.shadow' version '7.1.0'
 }


### PR DESCRIPTION
This bumps `loom-quiltflower-mini` to the latest version, 1.2.1. This allows the use of quiltflower 1.7.0.