### PR TITLE
Add zstd compression option.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,7 @@ configure (allprojects - project(":tests")) {
         implementation "com.electronwill.night-config:toml:${night_config_version}"
         implementation "org.threadly:threadly:${threadly_version}"
         implementation "net.objecthunter:exp4j:${exp4j_version}"
+        implementation "com.github.luben:zstd-jni:${zstd_jni_version}"
     }
 }
 
@@ -160,6 +161,7 @@ dependencies {
     include implementation("com.electronwill.night-config:core:${night_config_version}")
     include implementation("org.threadly:threadly:${threadly_version}")
     include implementation("net.objecthunter:exp4j:${exp4j_version}")
+    include implementation("com.github.luben:zstd-jni:${zstd_jni_version}")
 
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.

--- a/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/Config.java
+++ b/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/Config.java
@@ -26,6 +26,7 @@ public class Config {
                     1  for GZip (RFC1952) (Vanilla compatible)\s
                     2  for Zlib (RFC1950) (Vanilla default) (Vanilla compatible)\s
                     3  for Uncompressed (Fastest, but higher disk usage) (Vanilla compatible)\s
+                    4  for zstd (Vanilla Incompatible, won't loads world saved with it without this option)\s
                     \s
                     Original chunk data will still readable after modifying this option \s
                     as this option only affects newly stored chunks\s

--- a/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/Config.java
+++ b/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/Config.java
@@ -26,7 +26,7 @@ public class Config {
                     1  for GZip (RFC1952) (Vanilla compatible)\s
                     2  for Zlib (RFC1950) (Vanilla default) (Vanilla compatible)\s
                     3  for Uncompressed (Fastest, but higher disk usage) (Vanilla compatible)\s
-                    4  for zstd (Vanilla Incompatible, won't loads world saved with it without this option)\s
+                    4  for zstd Experimental, purposed for tests! (Vanilla INcompatible, won't loads worlds saved with this option without it)\s
                     \s
                     Original chunk data will still readable after modifying this option \s
                     as this option only affects newly stored chunks\s

--- a/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/ConfigConstants.java
+++ b/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/ConfigConstants.java
@@ -15,7 +15,7 @@ public class ConfigConstants {
             CHUNK_STREAM_VERSION = ChunkStreamVersion.DEFLATE;
         } else {
             final ChunkStreamVersion chunkStreamVersion = ChunkStreamVersion.get((int) Config.chunkStreamVersion);
-            if (chunkStreamVersion == null) {
+            if (Config.chunkStreamVersion != 4 && chunkStreamVersion == null) {
                 Config.LOGGER.warn("Unknown compression {}, using vanilla default instead", Config.chunkStreamVersion);
                 CHUNK_STREAM_VERSION = ChunkStreamVersion.DEFLATE;
             } else {

--- a/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/mixin/compression/increase_buffer_size/MixinChunkStreamVersion.java
+++ b/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/mixin/compression/increase_buffer_size/MixinChunkStreamVersion.java
@@ -1,5 +1,7 @@
 package com.ishland.c2me.opts.chunkio.mixin.compression.increase_buffer_size;
 
+import com.github.luben.zstd.ZstdInputStream;
+import com.github.luben.zstd.ZstdOutputStream;
 import net.minecraft.world.storage.ChunkStreamVersion;
 import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
@@ -10,12 +12,9 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.zip.Deflater;
-import java.util.zip.DeflaterOutputStream;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-import java.util.zip.Inflater;
-import java.util.zip.InflaterInputStream;
+import java.util.zip.*;
+
+import static com.ishland.c2me.opts.chunkio.common.Config.chunkStreamVersion;
 
 @SuppressWarnings("InvalidInjectorMethodSignature")
 @Mixin(ChunkStreamVersion.class)
@@ -25,7 +24,9 @@ public class MixinChunkStreamVersion {
     @Dynamic
     @Redirect(method = "<clinit>", at = @At(value = "NEW", target = "(ILnet/minecraft/world/storage/ChunkStreamVersion$Wrapper;Lnet/minecraft/world/storage/ChunkStreamVersion$Wrapper;)Lnet/minecraft/world/storage/ChunkStreamVersion;"))
     private static ChunkStreamVersion redirectChunkStreamVersionConstructor(int id, ChunkStreamVersion.Wrapper<InputStream> inputStreamWrapper, ChunkStreamVersion.Wrapper<OutputStream> outputStreamWrapper) {
-        if (id == 1) { // GZIP
+        if (chunkStreamVersion == 4) { // zstd
+            return new ChunkStreamVersion(id, in -> new ZstdInputStream(in), out -> new ZstdOutputStream(out));
+        } else if (id == 1) { // GZIP
             return new ChunkStreamVersion(id, in -> new GZIPInputStream(in, 16 * 1024), out -> new GZIPOutputStream(out, 16 * 1024));
         } else if (id == 2) { // DEFLATE
             return new ChunkStreamVersion(id, in -> new InflaterInputStream(in, new Inflater(), 16 * 1024), out -> new DeflaterOutputStream(out, new Deflater(), 16 * 1024));

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ async_util_version=0.1.0
 night_config_version=3.6.5
 threadly_version=7.0
 exp4j_version=0.4.8
+zstd_jni_version=1.5.2-4


### PR DESCRIPTION
It gives noticable i/o impact, but here is some unresolved issues when using with sodium. Assuming because I don't know how to add zstd type to VERSIONS hashmap.