### PR TITLE
Fix C2ME reintroducing MC-263340

### DIFF
--- a/c2me-opts-chunk-access/src/main/java/com/ishland/c2me/opts/chunk_access/mixin/region_capture/MixinChunkStatus.java
+++ b/c2me-opts-chunk-access/src/main/java/com/ishland/c2me/opts/chunk_access/mixin/region_capture/MixinChunkStatus.java
@@ -44,14 +44,16 @@ public abstract class MixinChunkStatus {
                                                                                     List<Chunk> chunks) {
         try {
             final ChunkStatus thiz = (ChunkStatus) (Object) this;
-            CurrentWorldGenState.setCurrentRegion(new ChunkRegion(world,chunks, thiz, -1));
+            CurrentWorldGenState.setCurrentRegion(new ChunkRegion(world, chunks, thiz, -1));
             Chunk chunk = chunks.get(chunks.size() / 2);
             Finishable finishable = FlightProfiler.INSTANCE.startChunkGenerationProfiling(chunk.getPos(), world.getRegistryKey(), this.toString());
             CompletableFuture<Either<Chunk, ChunkHolder.Unloaded>> completableFuture = this.generationTask.doWork(thiz, executor, world, generator, structureTemplateManager, lightingProvider, fullChunkConverter, chunks, chunk);
             return completableFuture.thenApply((either) -> {
-                if (chunk instanceof ProtoChunk protoChunk && !protoChunk.getStatus().isAtLeast(thiz)) {
-                    protoChunk.setStatus(thiz);
-                }
+                either.ifLeft(chunk1 -> {
+                    if (chunk1 instanceof ProtoChunk protoChunk && !protoChunk.getStatus().isAtLeast(thiz)) {
+                        protoChunk.setStatus(thiz);
+                    }
+                });
 
                 if (finishable != null) {
                     finishable.finish();


### PR DESCRIPTION
Message copied from the discord server:

> I am pretty sure C2ME re-introduces this bug: https://bugs.mojang.com/browse/MC-263340 in C2MEs [MixinChunkStatus](https://github.com/RelativityMC/C2ME-fabric/blob/ver/1.20.4/c2me-opts-chunk-access/src/main/java/com/ishland/c2me/opts/chunk_access/mixin/region_capture/MixinChunkStatus.java#L52), which is mostly a VanillaCopy. I have noticed this, because I got some [`Failed to save chunk {},{} asynchronously, falling back to sync saving`](https://github.com/RelativityMC/C2ME-fabric/blob/ver/1.20.4/c2me-threading-chunkio/src/main/java/com/ishland/c2me/threading/chunkio/mixin/MixinThreadedAnvilChunkStorage.java#L376) when updating and testing C2ME on 24w04a with fabric api, because Fabric API uses the chunk type [here](https://github.com/FabricMC/fabric/blob/1.20.4/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/ChunkSerializerMixin.java#L56) to check if a chunk is a LevelChunk, which caused a ClassCastException, because the chunk was a ProtoChunk and not LevelChunk, which implements that interface. I am not really sure why I only encountered this bug now, because I don't see a reason why it would be different in 24w04a than 1.20.4!
> 
> *(attached is Mojangs fix for the bug, in mojmap)*
When applying the same change Mojang made to C2MEs mixin this doesn't seem to happen anymore.

```diff
diff --git a/minecraft/src/net/minecraft/world/level/chunk/ChunkStatus.java b/minecraft/src/net/minecraft/world/level/chunk/ChunkStatus.java
index da3b216..e7dbfda 100755
--- a/minecraft/src/net/minecraft/world/level/chunk/ChunkStatus.java
+++ b/minecraft/src/net/minecraft/world/level/chunk/ChunkStatus.java
@@ -380,10 +380,11 @@ public class ChunkStatus {
 		return this.generationTask
 			.doWork(this, executor, serverLevel, chunkGenerator, structureTemplateManager, threadedLevelLightEngine, function, list, chunkAccess)
 			.thenApply(either -> {
-				if (chunkAccess instanceof ProtoChunk protoChunk && !protoChunk.getStatus().isOrAfter(this)) {
-					protoChunk.setStatus(this);
-				}
-	
+				either.ifLeft(chunkAccessx -> {
+					if (chunkAccessx instanceof ProtoChunk protoChunk && !protoChunk.getStatus().isOrAfter(this)) {
+						protoChunk.setStatus(this);
+					}
+				});
 				if (profiledDuration != null) {
 					profiledDuration.finish();
 				}
```