### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ configure (allprojects - project(":tests")) {
         implementation "com.electronwill.night-config:toml:${night_config_version}"
         implementation "net.objecthunter:exp4j:${exp4j_version}"
         implementation "org.jctools:jctools-core:${jctools_version}"
-        implementation annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:${mixinsquared_version}")
+        implementation annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${mixinsquared_version}")
         api "com.ishland.flowsched:flowsched"
     }
 }
@@ -173,7 +173,7 @@ dependencies {
     include implementation("com.electronwill.night-config:core:${night_config_version}")
     include implementation("net.objecthunter:exp4j:${exp4j_version}")
     include implementation("org.jctools:jctools-core:${jctools_version}")
-    include implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:${mixinsquared_version}"))
+    include implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${mixinsquared_version}"))
     include "io.reactivex.rxjava3:rxjava:${rxjava_version}"
     include "org.reactivestreams:reactive-streams:${reactive_streams_version}"
 //    include implementation("com.ishland.flowsched:flowsched")

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ configure (allprojects - project(":tests")) {
         implementation "com.electronwill.night-config:toml:${night_config_version}"
         implementation "net.objecthunter:exp4j:${exp4j_version}"
         implementation "org.jctools:jctools-core:${jctools_version}"
-        implementation annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${mixinsquared_version}")
+        implementation annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${mixinsquared_version}")
         api "com.ishland.flowsched:flowsched"
     }
 }
@@ -173,7 +173,7 @@ dependencies {
     include implementation("com.electronwill.night-config:core:${night_config_version}")
     include implementation("net.objecthunter:exp4j:${exp4j_version}")
     include implementation("org.jctools:jctools-core:${jctools_version}")
-    include implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${mixinsquared_version}"))
+    include implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${mixinsquared_version}"))
     include "io.reactivex.rxjava3:rxjava:${rxjava_version}"
     include "org.reactivestreams:reactive-streams:${reactive_streams_version}"
 //    include implementation("com.ishland.flowsched:flowsched")


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_