### PR TITLE
Removed unneeded disabling of world.player_chunk_tick

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,12 +37,5 @@
   "breaks": {
     "tic_tacs": "*",
     "optifabric": "*"
-  },
-
-  "custom": {
-    "_lithium_toggle_comment": "We disable the player_chunk_tick mixin as some weird incompatibility is present, you are free to remove this and test the incompatibility issue",
-    "lithium:options": {
-      "mixin.world.player_chunk_tick": false
-    }
   }
 }


### PR DESCRIPTION
This problematic mixin has been removed from lithium [ddfaae6](https://github.com/CaffeineMC/lithium-fabric/commit/ddfaae6b1ddfa5b20fefa4952840e79b3cb89a8d). So this code is no longer needed.