### PR TITLE
Avoid unnecessary rehash in ChunkLevelManager and TicketDistanceLevelPropagator

### DIFF
--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkLevelManager.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkLevelManager.java
@@ -6,6 +6,8 @@ import com.ishland.c2me.rewrites.chunksystem.common.ducks.TicketDistanceLevelPro
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.unimi.dsi.fastutil.longs.Long2IntLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.objects.ObjectBidirectionalIterator;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkLevelManager;
 import net.minecraft.server.world.ServerChunkLoadingManager;
@@ -78,9 +80,11 @@ public abstract class MixinChunkLevelManager {
     private void postTicketPropagator(ServerChunkLoadingManager chunkLoadingManager, CallbackInfoReturnable<Boolean> cir) {
         if (this.ticketDistanceLevelPropagator != null) { // ignore if replaced
             Long2IntLinkedOpenHashMap updates = ((TicketDistanceLevelPropagatorExtension) this.ticketDistanceLevelPropagator).c2me$getTicketLevelUpdates();
-            updates.long2IntEntrySet().fastForEach(entry -> {
+            ObjectBidirectionalIterator<Long2IntMap.Entry> iterator = updates.long2IntEntrySet().fastIterator();
+            while (iterator.hasNext()) {
+                Long2IntMap.Entry entry = iterator.next();
                 this.setLevel(entry.getLongKey(), entry.getIntValue(), null, Integer.MAX_VALUE - 1); // holder and old level is ignored
-            });
+            }
             updates.clear();
         }
     }

--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkLevelManager.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkLevelManager.java
@@ -6,6 +6,8 @@ import com.ishland.c2me.rewrites.chunksystem.common.ducks.TicketDistanceLevelPro
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.unimi.dsi.fastutil.longs.Long2IntLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.objects.ObjectBidirectionalIterator;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkLevelManager;
 import net.minecraft.server.world.ServerChunkLoadingManager;
@@ -78,11 +80,12 @@ public abstract class MixinChunkLevelManager {
     private void postTicketPropagator(ServerChunkLoadingManager chunkLoadingManager, CallbackInfoReturnable<Boolean> cir) {
         if (this.ticketDistanceLevelPropagator != null) { // ignore if replaced
             Long2IntLinkedOpenHashMap updates = ((TicketDistanceLevelPropagatorExtension) this.ticketDistanceLevelPropagator).c2me$getTicketLevelUpdates();
-            while (!updates.isEmpty()) {
-                long pos = updates.firstLongKey();
-                int level = updates.removeFirstInt();
-                this.setLevel(pos, level, null, Integer.MAX_VALUE - 1); // holder and old level is ignored
+            ObjectBidirectionalIterator<Long2IntMap.Entry> iterator = updates.long2IntEntrySet().fastIterator();
+            while (iterator.hasNext()) {
+                Long2IntMap.Entry entry = iterator.next();
+                this.setLevel(entry.getLongKey(), entry.getIntValue(), null, Integer.MAX_VALUE - 1); // holder and old level is ignored
             }
+            updates.clear();
         }
     }
 

--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkLevelManager.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkLevelManager.java
@@ -6,8 +6,6 @@ import com.ishland.c2me.rewrites.chunksystem.common.ducks.TicketDistanceLevelPro
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.unimi.dsi.fastutil.longs.Long2IntLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2IntMap;
-import it.unimi.dsi.fastutil.objects.ObjectBidirectionalIterator;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkLevelManager;
 import net.minecraft.server.world.ServerChunkLoadingManager;
@@ -80,11 +78,9 @@ public abstract class MixinChunkLevelManager {
     private void postTicketPropagator(ServerChunkLoadingManager chunkLoadingManager, CallbackInfoReturnable<Boolean> cir) {
         if (this.ticketDistanceLevelPropagator != null) { // ignore if replaced
             Long2IntLinkedOpenHashMap updates = ((TicketDistanceLevelPropagatorExtension) this.ticketDistanceLevelPropagator).c2me$getTicketLevelUpdates();
-            ObjectBidirectionalIterator<Long2IntMap.Entry> iterator = updates.long2IntEntrySet().fastIterator();
-            while (iterator.hasNext()) {
-                Long2IntMap.Entry entry = iterator.next();
+            updates.long2IntEntrySet().fastForEach(entry -> {
                 this.setLevel(entry.getLongKey(), entry.getIntValue(), null, Integer.MAX_VALUE - 1); // holder and old level is ignored
-            }
+            });
             updates.clear();
         }
     }

--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkTicketManagerTicketDistanceLevelPropagator.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkTicketManagerTicketDistanceLevelPropagator.java
@@ -32,7 +32,7 @@ public class MixinChunkTicketManagerTicketDistanceLevelPropagator implements Tic
         this.c2me$ticketLevelUpdates = new Long2IntLinkedOpenHashMap() {
             @Override
             protected void rehash(int newN) {
-                if (newN < this.size) {
+                if (newN <= n) {
                     return; // prevent shrinking
                 }
                 super.rehash(newN);

--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkTicketManagerTicketDistanceLevelPropagator.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkTicketManagerTicketDistanceLevelPropagator.java
@@ -29,7 +29,15 @@ public class MixinChunkTicketManagerTicketDistanceLevelPropagator implements Tic
     private void postInit(CallbackInfo ci) {
         this.c2me$levels = new Long2IntOpenHashMap();
         this.c2me$levels.defaultReturnValue(UNLOADED + 1);
-        this.c2me$ticketLevelUpdates = new Long2IntLinkedOpenHashMap();
+        this.c2me$ticketLevelUpdates = new Long2IntLinkedOpenHashMap() {
+            @Override
+            protected void rehash(int newN) {
+                if (newN < this.size) {
+                    return; // prevent shrinking
+                }
+                super.rehash(newN);
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
In ChunkLevelManager, ticket level updates are applied by removing the first entry from the update map. This introduces unnecessary shiftKey and rehash logics in our use case. We can avoid them all.