### PR TITLE
Make VMP MixinSquared `ChunkTicketManager` hooks optional (NeoForge–safe, Fabric+VMP preserved)

### DIFF
--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/MixinPlugin.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/MixinPlugin.java
@@ -3,17 +3,50 @@ package com.ishland.c2me.rewrites.chunksystem;
 import com.ishland.c2me.base.common.ModuleMixinPlugin;
 import com.ishland.c2me.rewrites.chunksystem.common.Config;
 
+/**
+ * Mixin gating. VMP MixinSquared hooks ({@code MixinChunkTicketManagerVmp}) are off on NeoForge and on Fabric when VMP is absent.
+ */
 public class MixinPlugin extends ModuleMixinPlugin {
+
+    private static final String VMP_MIXIN_CLASS = "com.ishland.c2me.rewrites.chunksystem.mixin.vmp.MixinChunkTicketManagerVmp";
+    private static final String NEO_FORGE_FML_LOADER = "net.neoforged.fml.loading.FMLLoader";
+    private static final String VMP_TICKET_MIXIN = "com.ishland.vmp.mixins.ticketsystem.ticketpropagator.MixinChunkTicketManager";
+
+    private static final boolean C2ME_NEO_FORGE = classPresent(NEO_FORGE_FML_LOADER);
+    private static final boolean C2ME_VMP_TICKET_TARGET = classPresent(VMP_TICKET_MIXIN);
+
+    private static boolean classPresent(String binaryName) {
+        try {
+            Class.forName(binaryName, false, MixinPlugin.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException | LinkageError e) {
+            return false;
+        }
+    }
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        if (!super.shouldApplyMixin(targetClassName, mixinClassName))
+        if (!super.shouldApplyMixin(targetClassName, mixinClassName)) {
             return false;
+        }
 
-        if (mixinClassName.startsWith("com.ishland.c2me.rewrites.chunksystem.mixin.fluid_postprocessing"))
+        if (VMP_MIXIN_CLASS.equals(mixinClassName)) {
+            if (C2ME_NEO_FORGE) {
+                LOGGER.debug("Skipping {} (VMP MixinSquared hooks not used on NeoForge)", mixinClassName);
+                return false;
+            }
+            if (!C2ME_VMP_TICKET_TARGET) {
+                LOGGER.debug("Skipping {} (VMP ticket mixin not on classpath)", mixinClassName);
+                return false;
+            }
+        }
+
+        if (mixinClassName.startsWith("com.ishland.c2me.rewrites.chunksystem.mixin.fluid_postprocessing")) {
             return Config.fluidPostProcessingToScheduledTick;
-        if (mixinClassName.startsWith("com.ishland.c2me.rewrites.chunksystem.mixin.async_chunkio."))
+        }
+        if (mixinClassName.startsWith("com.ishland.c2me.rewrites.chunksystem.mixin.async_chunkio.")) {
             return Config.asyncSerialization;
+        }
 
         return true;
     }

--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkTicketManager.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkTicketManager.java
@@ -1,6 +1,5 @@
 package com.ishland.c2me.rewrites.chunksystem.mixin;
 
-import com.bawnorton.mixinsquared.TargetHandler;
 import com.ishland.c2me.rewrites.chunksystem.common.Config;
 import com.ishland.c2me.rewrites.chunksystem.common.ducks.TicketDistanceLevelPropagatorExtension;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -11,14 +10,11 @@ import net.minecraft.server.world.ChunkTaskPrioritySystem;
 import net.minecraft.server.world.ChunkTicketManager;
 import net.minecraft.server.world.ServerChunkLoadingManager;
 import org.jetbrains.annotations.Nullable;
-import org.objectweb.asm.Opcodes;
-import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
@@ -33,36 +29,6 @@ public abstract class MixinChunkTicketManager {
     @Shadow
     @Final
     private ChunkTicketManager.TicketDistanceLevelPropagator distanceFromTicketTracker;
-
-    @Dynamic
-    @TargetHandler(
-            mixin = "com.ishland.vmp.mixins.ticketsystem.ticketpropagator.MixinChunkTicketManager",
-            name = "tickTickets"
-    )
-    @Redirect(method = "@MixinSquared:Handler", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;getLevel()I"), require = 0)
-    private int fakeLevel(ChunkHolder instance) {
-        return Integer.MAX_VALUE;
-    }
-
-    @Dynamic
-    @TargetHandler(
-            mixin = "com.ishland.vmp.mixins.ticketsystem.ticketpropagator.MixinChunkTicketManager",
-            name = "tickTickets"
-    )
-    @Redirect(method = "@MixinSquared:Handler", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkTicketManager;getChunkHolder(J)Lnet/minecraft/server/world/ChunkHolder;"), require = 0)
-    private ChunkHolder fakeLevel(ChunkTicketManager instance, long l) {
-        return null;
-    }
-
-    @Dynamic
-    @TargetHandler(
-            mixin = "com.ishland.vmp.mixins.ticketsystem.ticketpropagator.MixinChunkTicketManager",
-            name = "tickTickets"
-    )
-    @Redirect(method = "@MixinSquared:Handler", at = @At(value = "FIELD", target = "Lnet/minecraft/server/world/ChunkLevels;INACCESSIBLE:I", opcode = Opcodes.GETSTATIC, ordinal = 0), require = 0)
-    private int fakeLevel() {
-        return Integer.MAX_VALUE - 1;
-    }
 
     @WrapOperation(method = "<init>", at = @At(value = "NEW", target = "(Ljava/util/List;Ljava/util/concurrent/Executor;I)Lnet/minecraft/server/world/ChunkTaskPrioritySystem;"))
     private ChunkTaskPrioritySystem syncPlayerTickets(List actors, Executor executor, int maxQueues, Operation<ChunkTaskPrioritySystem> original) {

--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/vmp/MixinChunkTicketManagerVmp.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/vmp/MixinChunkTicketManagerVmp.java
@@ -1,0 +1,73 @@
+package com.ishland.c2me.rewrites.chunksystem.mixin.vmp;
+
+import com.bawnorton.mixinsquared.TargetHandler;
+import net.minecraft.server.world.ChunkHolder;
+import net.minecraft.server.world.ChunkTicketManager;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * MixinSquared integration with Volumetrica/VMP's {@code MixinChunkTicketManager#tickTickets}.
+ * <p>
+ * <b>Not applied on NeoForge</b> (VMP is not on the classpath; MixinSquared would fail to resolve
+ * {@link TargetHandler} targets). See {@link com.ishland.c2me.rewrites.chunksystem.MixinPlugin}.
+ * <p>
+ * <b>Applied on Fabric</b> only when the VMP target mixin is present (see
+ * {@link com.ishland.c2me.rewrites.chunksystem.MixinPlugin#shouldApplyMixin}).
+ */
+@Mixin(value = ChunkTicketManager.class, priority = 1050)
+public abstract class MixinChunkTicketManagerVmp {
+
+    @Dynamic
+    @TargetHandler(
+            mixin = "com.ishland.vmp.mixins.ticketsystem.ticketpropagator.MixinChunkTicketManager",
+            name = "tickTickets"
+    )
+    @Redirect(
+            method = "@MixinSquared:Handler",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;getLevel()I"),
+            require = 0
+    )
+    private int fakeLevelForVmp(ChunkHolder instance) {
+        return Integer.MAX_VALUE;
+    }
+
+    @Dynamic
+    @TargetHandler(
+            mixin = "com.ishland.vmp.mixins.ticketsystem.ticketpropagator.MixinChunkTicketManager",
+            name = "tickTickets"
+    )
+    @Redirect(
+            method = "@MixinSquared:Handler",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/world/ChunkTicketManager;getChunkHolder(J)Lnet/minecraft/server/world/ChunkHolder;"
+            ),
+            require = 0
+    )
+    private ChunkHolder fakeLevelForVmp(ChunkTicketManager instance, long pos) {
+        return null;
+    }
+
+    @Dynamic
+    @TargetHandler(
+            mixin = "com.ishland.vmp.mixins.ticketsystem.ticketpropagator.MixinChunkTicketManager",
+            name = "tickTickets"
+    )
+    @Redirect(
+            method = "@MixinSquared:Handler",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/server/world/ChunkLevels;INACCESSIBLE:I",
+                    opcode = Opcodes.GETSTATIC,
+                    ordinal = 0
+            ),
+            require = 0
+    )
+    private int fakeInaccessibleForVmp() {
+        return Integer.MAX_VALUE - 1;
+    }
+}

--- a/c2me-rewrites-chunk-system/src/main/resources/c2me-rewrites-chunk-system.mixins.json
+++ b/c2me-rewrites-chunk-system/src/main/resources/c2me-rewrites-chunk-system.mixins.json
@@ -7,6 +7,7 @@
     "MixinChunkGenerator",
     "MixinChunkHolder",
     "MixinChunkTicketManager",
+    "vmp.MixinChunkTicketManagerVmp",
     "MixinChunkTicketManagerTicketDistanceLevelPropagator",
     "MixinMinecraftServer",
     "MixinNoiseChunkGenerator",


### PR DESCRIPTION
With VMP not being available on Neo 1.21.1 and the mixins not being optional, this was causing some mixin conflicts in a larger modpack. Made them optional and Fabric-only.