### PR TITLE
Reuse deflaters for region file chunk writes

### DIFF
--- a/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/Config.java
+++ b/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/Config.java
@@ -18,6 +18,11 @@ public class Config {
             .comment("Hard limit for io worker nbt cache")
             .getLong(32678, 32678, ConfigSystem.LongChecks.POSITIVE_VALUES_ONLY);
 
+    public static final boolean reuseDeflaters = new ConfigSystem.ConfigAccessor()
+            .key("ioSystem.reuseDeflaters")
+            .comment("Reuse a per-thread Deflater for region file chunk writes instead of allocating one per write. Output is byte-identical.")
+            .getBoolean(true, false);
+
     public static void init() {
     }
 

--- a/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/DeflaterPool.java
+++ b/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/common/DeflaterPool.java
@@ -1,0 +1,43 @@
+package com.ishland.c2me.opts.chunkio.common;
+
+import java.io.OutputStream;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+
+/**
+ * Reuses a per-thread {@link Deflater} for region file chunk writes.
+ *
+ * Vanilla wraps every chunk write in a {@code new DeflaterOutputStream(out)}, which allocates a fresh
+ * {@link Deflater} (a native zlib stream init) and frees it on close (native end). Under sustained chunk
+ * saving this shows up as Deflater.init and Deflater.end self-time on the IO threads.
+ *
+ * A {@link Deflater} created with the no-arg constructor matches vanilla's compression level and zlib
+ * wrapping. {@link Deflater#reset()} clears stream state while keeping those settings, so a reused,
+ * reset deflater produces byte-identical output to a freshly allocated one. Saved region files stay
+ * readable by vanilla and other tools.
+ *
+ * The deflater is held in a {@link ThreadLocal} because region IO runs across several worker threads, and
+ * each write on a given thread runs to completion before the next, so no locking is needed. When a
+ * {@link Deflater} is passed to {@link DeflaterOutputStream#DeflaterOutputStream(OutputStream, Deflater)},
+ * the stream's close() finishes but does not end() it, so the same instance survives for the next write.
+ */
+public final class DeflaterPool {
+
+    private static final ThreadLocal<Deflater> DEFLATER = ThreadLocal.withInitial(Deflater::new);
+
+    private DeflaterPool() {
+    }
+
+    /**
+     * Wraps the given stream with a {@link DeflaterOutputStream} backed by the calling thread's reused
+     * deflater. The deflater is reset before use, so the produced bytes match a fresh deflater exactly.
+     * The default 512 byte internal buffer matches vanilla's DeflaterOutputStream, keeping flush
+     * boundaries and therefore output identical.
+     */
+    public static DeflaterOutputStream wrap(OutputStream out) {
+        final Deflater deflater = DEFLATER.get();
+        deflater.reset();
+        return new DeflaterOutputStream(out, deflater);
+    }
+
+}

--- a/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/mixin/reuse_deflater/MixinChunkCompressionFormat.java
+++ b/c2me-opts-chunkio/src/main/java/com/ishland/c2me/opts/chunkio/mixin/reuse_deflater/MixinChunkCompressionFormat.java
@@ -1,0 +1,37 @@
+package com.ishland.c2me.opts.chunkio.mixin.reuse_deflater;
+
+import com.ishland.c2me.opts.chunkio.common.Config;
+import com.ishland.c2me.opts.chunkio.common.DeflaterPool;
+import net.minecraft.world.storage.ChunkCompressionFormat;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Routes deflate chunk writes through a reused per-thread Deflater instead of allocating one per write.
+ *
+ * Vanilla's DEFLATE format wraps each chunk write in a single-arg new DeflaterOutputStream(stream), which
+ * allocates a fresh Deflater (native zlib init) and ends it on close (native end). This intercepts the
+ * wrap call for the DEFLATE format only and returns a stream backed by a pooled deflater, removing the
+ * per-write init and end. Other formats (gzip, lz4, uncompressed, custom) are left untouched. The produced
+ * bytes are identical, so existing region files stay readable.
+ */
+@Mixin(ChunkCompressionFormat.class)
+public class MixinChunkCompressionFormat {
+
+    @Shadow @Final public static ChunkCompressionFormat DEFLATE;
+
+    @Inject(method = "wrap(Ljava/io/OutputStream;)Ljava/io/OutputStream;", at = @At("HEAD"), cancellable = true)
+    private void reuseDeflater(OutputStream stream, CallbackInfoReturnable<OutputStream> cir) throws IOException {
+        if (Config.reuseDeflaters && (Object) this == DEFLATE) {
+            cir.setReturnValue(DeflaterPool.wrap(stream));
+        }
+    }
+
+}

--- a/c2me-opts-chunkio/src/main/resources/c2me-opts-chunkio.mixins.json
+++ b/c2me-opts-chunkio/src/main/resources/c2me-opts-chunkio.mixins.json
@@ -5,6 +5,7 @@
   "plugin": "com.ishland.c2me.opts.chunkio.MixinPlugin",
   "mixins": [
     "hide_sync_disk_writes_behind_flag.MixinRegionBasedStorage",
-    "limit_nbt_cache.MixinStorageIoWorker"
+    "limit_nbt_cache.MixinStorageIoWorker",
+    "reuse_deflater.MixinChunkCompressionFormat"
   ]
 }


### PR DESCRIPTION
Reuses a per-thread `Deflater` for region file chunk writes instead of allocating a new one per write.

Vanilla's DEFLATE format wraps every chunk write in `new DeflaterOutputStream(stream)`, allocating a fresh `Deflater` (native zlib init) and freeing it on close (native end), on every write. This reuses a per-thread `Deflater` that is `reset()` before each write and passed to `DeflaterOutputStream(out, deflater)`, so `close()` finishes the stream without ending the deflater and the instance is reused. A no-arg `Deflater` matches vanilla's compression level and zlib wrapping, and `reset()` keeps those settings, so output is byte-identical and existing region files stay readable. Only the DEFLATE format is intercepted (gzip, lz4, uncompressed, custom untouched). Gated behind `ioSystem.reuseDeflaters` (default on).

Measured on 1.21.1 with spark `--thread *` (self-time on the IO threads, both profiles attached): [c2me-deflater-spark-profiles.zip](https://github.com/user-attachments/files/28722676/c2me-deflater-spark-profiles.zip)

reuseDeflaters=false:
Deflater.init = 13,652 ms
Deflater.end = 9,536 ms

reuseDeflaters=true:
Deflater.init = 0 ms
Deflater.end = 0 ms
Deflater.reset = 1,820 ms

The per-write allocate and free (init + end = 23,188 ms, roughly equal to the run's actual compression time) is eliminated and replaced by a small reset. Compression itself (`deflateBytesBytes`) is unchanged.

Compression runs as discrete tasks on the chunk-IO pool: `C2MEStorageThread` dispatches wrap -> write -> close via `supplyAsync(..., prioritizedScheduler.executor(16))`, each task completes before the next, and a pool thread runs one at a time, so the `ThreadLocal` deflater is never used by two streams concurrently. Reads use `Inflater` and are untouched.

`Deflater.reset()` preserves compression level, strategy, and zlib wrapping, so a reused deflater produces the same bytes as a fresh one. 

Verified over 2000 iterations of mixed random and compressible data: all 2000 outputs were byte-identical to a fresh `Deflater` and round-tripped through `Inflater` (0 mismatches). In-game, chunks save under sustained load and reload with no corruption.

<details>
<summary>Byte-identical validation test</summary>

```java
import java.io.*;
import java.util.*;
import java.util.zip.*;

// Proves a reused, reset() Deflater produces byte-identical output to a fresh
// Deflater per write (and that the output still inflates back), across many reuses.
public class DeflaterEquivTest {

    // vanilla path: a fresh default Deflater per write (new DeflaterOutputStream(out))
    static byte[] vanilla(byte[] data) throws IOException {
        ByteArrayOutputStream bos = new ByteArrayOutputStream();
        try (DeflaterOutputStream dos = new DeflaterOutputStream(bos)) { dos.write(data); }
        return bos.toByteArray();
    }

    // pooled path: one reused Deflater, reset() before use, passed in so close() does not end() it
    static byte[] pooled(Deflater shared, byte[] data) throws IOException {
        shared.reset();
        ByteArrayOutputStream bos = new ByteArrayOutputStream();
        try (DeflaterOutputStream dos = new DeflaterOutputStream(bos, shared)) { dos.write(data); }
        return bos.toByteArray();
    }

    static byte[] inflate(byte[] c) throws IOException {
        try (InflaterInputStream in = new InflaterInputStream(new ByteArrayInputStream(c))) {
            return in.readAllBytes();
        }
    }

    public static void main(String[] args) throws IOException {
        Random rnd = new Random(42);
        Deflater shared = new Deflater();      // reused across every iteration, like the ThreadLocal
        int n = 2000, mismatches = 0;
        for (int i = 0; i < n; i++) {
            byte[] data = new byte[rnd.nextInt(40000)];
            if (i % 3 == 0) rnd.nextBytes(data);                                  // incompressible
            else for (int j = 0; j < data.length; j++) data[j] = (byte) (j % (1 + i % 17)); // compressible

            if (!Arrays.equals(vanilla(data), pooled(shared, data))) mismatches++; // identical bytes
            if (!Arrays.equals(inflate(pooled(shared, data)), data)) mismatches++;  // round-trips
        }
        System.out.println("iterations=" + n + " mismatches=" + mismatches
            + (mismatches == 0 ? " -> PASS (byte-identical, round-trips)" : " -> FAIL"));
    }
}
```

Output:

```
iterations=2000 mismatches=0 -> PASS (byte-identical, round-trips)
```

</details>
