### PR TITLE
Optimize worldgen structure and feature selection

### DIFF
--- a/c2me-opts-worldgen-vanilla/src/main/java/com/ishland/c2me/opts/worldgen/vanilla/mixin/structure_weight_sampler/MixinStructureWeightSampler.java
+++ b/c2me-opts-worldgen-vanilla/src/main/java/com/ishland/c2me/opts/worldgen/vanilla/mixin/structure_weight_sampler/MixinStructureWeightSampler.java
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.objects.ObjectListIterator;
 import net.minecraft.structure.JigsawJunction;
 import net.minecraft.util.math.BlockBox;
 import net.minecraft.world.gen.StructureWeightSampler;
+import net.minecraft.world.gen.StructureTerrainAdaptation;
 import net.minecraft.world.gen.densityfunction.DensityFunction;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,6 +15,18 @@ import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(StructureWeightSampler.class)
 public abstract class MixinStructureWeightSampler {
+
+    @Unique
+    private static final int C2ME$BOUNDS_STRIDE = 6;
+
+    @Unique
+    private static final int C2ME$MAGNITUDE_INFLUENCE = 5;
+
+    @Unique
+    private static final int C2ME$BEARD_NEGATIVE_INFLUENCE = 12;
+
+    @Unique
+    private static final int C2ME$BEARD_POSITIVE_INFLUENCE = 11;
 
     @Shadow @Final private ObjectListIterator<StructureWeightSampler.Piece> pieceIterator;
 
@@ -31,11 +44,39 @@ public abstract class MixinStructureWeightSampler {
     private JigsawJunction[] c2me$junctionArray;
 
     @Unique
+    private int[] c2me$pieceBounds;
+
+    @Unique
+    private int[] c2me$junctionBounds;
+
+    @Unique
+    private int c2me$minX;
+
+    @Unique
+    private int c2me$maxX;
+
+    @Unique
+    private int c2me$minY;
+
+    @Unique
+    private int c2me$maxY;
+
+    @Unique
+    private int c2me$minZ;
+
+    @Unique
+    private int c2me$maxZ;
+
+    @Unique
+    private boolean c2me$hasInfluence;
+
+    @Unique
     private void c2me$initArrays() {
         this.c2me$pieceArray = Iterators.toArray(this.pieceIterator, StructureWeightSampler.Piece.class);
         this.pieceIterator.back(Integer.MAX_VALUE);
         this.c2me$junctionArray = Iterators.toArray(this.junctionIterator, JigsawJunction.class);
         this.junctionIterator.back(Integer.MAX_VALUE);
+        this.c2me$initInfluenceBounds();
     }
 
     /**
@@ -48,32 +89,28 @@ public abstract class MixinStructureWeightSampler {
             this.c2me$initArrays();
         }
 
-        int i = pos.blockX();
         int j = pos.blockY();
+        if (!this.c2me$hasInfluence || j < this.c2me$minY || j > this.c2me$maxY) {
+            return 0.0;
+        }
+
+        int i = pos.blockX();
         int k = pos.blockZ();
+        if (i < this.c2me$minX || i > this.c2me$maxX || k < this.c2me$minZ || k > this.c2me$maxZ) {
+            return 0.0;
+        }
+
         double d = 0.0;
 
-        for (StructureWeightSampler.Piece piece : this.c2me$pieceArray) {
+        for (int pieceIndex = 0, boundsIndex = 0; pieceIndex < this.c2me$pieceArray.length; ++pieceIndex, boundsIndex += C2ME$BOUNDS_STRIDE) {
+            if (c2me$isOutsideBounds(this.c2me$pieceBounds, boundsIndex, i, j, k)) continue;
+            StructureWeightSampler.Piece piece = this.c2me$pieceArray[pieceIndex];
             BlockBox blockBox = piece.box();
             int l = piece.groundLevelDelta();
             int m = Math.max(0, Math.max(blockBox.getMinX() - i, i - blockBox.getMaxX()));
             int n = Math.max(0, Math.max(blockBox.getMinZ() - k, k - blockBox.getMaxZ()));
             int o = blockBox.getMinY() + l;
             int p = j - o;
-
-//            int q = switch (piece.terrainAdjustment()) {
-//                case NONE -> 0;
-//                case BURY, BEARD_THIN -> p;
-//                case BEARD_BOX -> Math.max(0, Math.max(o - j, j - blockBox.getMaxY()));
-//                case ENCAPSULATE -> Math.max(0, Math.max(blockBox.getMinY() - j, j - blockBox.getMaxY()));
-//            };
-//
-//            d += switch (piece.terrainAdjustment()) {
-//                case NONE -> 0.0;
-//                case BURY -> getMagnitudeWeight(m, (double)q / 2.0, n);
-//                case BEARD_THIN, BEARD_BOX -> getStructureWeight(m, q, n, p) * 0.8;
-//                case ENCAPSULATE -> getMagnitudeWeight((double)m / 2.0, (double)q / 2.0, (double)n / 2.0) * 0.8;
-//            };
 
             d += switch (piece.terrainAdjustment()) { // 2 switch statement merged
                 case NONE -> 0.0;
@@ -84,7 +121,9 @@ public abstract class MixinStructureWeightSampler {
             };
         }
 
-        for (JigsawJunction jigsawJunction : this.c2me$junctionArray) {
+        for (int junctionIndex = 0, boundsIndex = 0; junctionIndex < this.c2me$junctionArray.length; ++junctionIndex, boundsIndex += C2ME$BOUNDS_STRIDE) {
+            if (c2me$isOutsideBounds(this.c2me$junctionBounds, boundsIndex, i, j, k)) continue;
+            JigsawJunction jigsawJunction = this.c2me$junctionArray[junctionIndex];
             int r = i - jigsawJunction.getSourceX();
             int l = j - jigsawJunction.getSourceGroundY();
             int m = k - jigsawJunction.getSourceZ();
@@ -106,6 +145,113 @@ public abstract class MixinStructureWeightSampler {
         } else {
             return 1.0 - d / 6.0;
         }
+    }
+
+    @Unique
+    private void c2me$initInfluenceBounds() {
+        this.c2me$pieceBounds = new int[this.c2me$pieceArray.length * C2ME$BOUNDS_STRIDE];
+        this.c2me$junctionBounds = new int[this.c2me$junctionArray.length * C2ME$BOUNDS_STRIDE];
+        this.c2me$resetGlobalBounds();
+
+        for (int i = 0, base = 0; i < this.c2me$pieceArray.length; ++i, base += C2ME$BOUNDS_STRIDE) {
+            if (this.c2me$setPieceBounds(this.c2me$pieceArray[i], this.c2me$pieceBounds, base)) {
+                this.c2me$includeBounds(this.c2me$pieceBounds, base);
+            }
+        }
+
+        for (int i = 0, base = 0; i < this.c2me$junctionArray.length; ++i, base += C2ME$BOUNDS_STRIDE) {
+            this.c2me$setJunctionBounds(this.c2me$junctionArray[i], this.c2me$junctionBounds, base);
+            this.c2me$includeBounds(this.c2me$junctionBounds, base);
+        }
+    }
+
+    @Unique
+    private boolean c2me$setPieceBounds(StructureWeightSampler.Piece piece, int[] bounds, int base) {
+        BlockBox box = piece.box();
+        StructureTerrainAdaptation adjustment = piece.terrainAdjustment();
+        int groundY = box.getMinY() + piece.groundLevelDelta();
+
+        return switch (adjustment) {
+            case NONE -> false;
+            case BURY -> {
+                c2me$setBounds(bounds, base,
+                        box.getMinX() - C2ME$MAGNITUDE_INFLUENCE, box.getMaxX() + C2ME$MAGNITUDE_INFLUENCE,
+                        groundY - C2ME$BEARD_POSITIVE_INFLUENCE, groundY + C2ME$BEARD_POSITIVE_INFLUENCE,
+                        box.getMinZ() - C2ME$MAGNITUDE_INFLUENCE, box.getMaxZ() + C2ME$MAGNITUDE_INFLUENCE);
+                yield true;
+            }
+            case BEARD_THIN -> {
+                c2me$setBounds(bounds, base,
+                        box.getMinX() - C2ME$BEARD_POSITIVE_INFLUENCE, box.getMaxX() + C2ME$BEARD_POSITIVE_INFLUENCE,
+                        groundY - C2ME$BEARD_NEGATIVE_INFLUENCE, groundY + C2ME$BEARD_POSITIVE_INFLUENCE,
+                        box.getMinZ() - C2ME$BEARD_POSITIVE_INFLUENCE, box.getMaxZ() + C2ME$BEARD_POSITIVE_INFLUENCE);
+                yield true;
+            }
+            case BEARD_BOX -> {
+                c2me$setBounds(bounds, base,
+                        box.getMinX() - C2ME$BEARD_POSITIVE_INFLUENCE, box.getMaxX() + C2ME$BEARD_POSITIVE_INFLUENCE,
+                        groundY - C2ME$BEARD_POSITIVE_INFLUENCE, box.getMaxY() + C2ME$BEARD_POSITIVE_INFLUENCE,
+                        box.getMinZ() - C2ME$BEARD_POSITIVE_INFLUENCE, box.getMaxZ() + C2ME$BEARD_POSITIVE_INFLUENCE);
+                yield true;
+            }
+            case ENCAPSULATE -> {
+                c2me$setBounds(bounds, base,
+                        box.getMinX() - C2ME$BEARD_POSITIVE_INFLUENCE, box.getMaxX() + C2ME$BEARD_POSITIVE_INFLUENCE,
+                        box.getMinY() - C2ME$BEARD_POSITIVE_INFLUENCE, box.getMaxY() + C2ME$BEARD_POSITIVE_INFLUENCE,
+                        box.getMinZ() - C2ME$BEARD_POSITIVE_INFLUENCE, box.getMaxZ() + C2ME$BEARD_POSITIVE_INFLUENCE);
+                yield true;
+            }
+        };
+    }
+
+    @Unique
+    private void c2me$setJunctionBounds(JigsawJunction junction, int[] bounds, int base) {
+        c2me$setBounds(bounds, base,
+                junction.getSourceX() - C2ME$BEARD_NEGATIVE_INFLUENCE,
+                junction.getSourceX() + C2ME$BEARD_POSITIVE_INFLUENCE,
+                junction.getSourceGroundY() - C2ME$BEARD_NEGATIVE_INFLUENCE,
+                junction.getSourceGroundY() + C2ME$BEARD_POSITIVE_INFLUENCE,
+                junction.getSourceZ() - C2ME$BEARD_NEGATIVE_INFLUENCE,
+                junction.getSourceZ() + C2ME$BEARD_POSITIVE_INFLUENCE);
+    }
+
+    @Unique
+    private static void c2me$setBounds(int[] bounds, int base, int minX, int maxX, int minY, int maxY, int minZ, int maxZ) {
+        bounds[base] = minX;
+        bounds[base + 1] = maxX;
+        bounds[base + 2] = minY;
+        bounds[base + 3] = maxY;
+        bounds[base + 4] = minZ;
+        bounds[base + 5] = maxZ;
+    }
+
+    @Unique
+    private void c2me$resetGlobalBounds() {
+        this.c2me$minX = Integer.MAX_VALUE;
+        this.c2me$maxX = Integer.MIN_VALUE;
+        this.c2me$minY = Integer.MAX_VALUE;
+        this.c2me$maxY = Integer.MIN_VALUE;
+        this.c2me$minZ = Integer.MAX_VALUE;
+        this.c2me$maxZ = Integer.MIN_VALUE;
+        this.c2me$hasInfluence = false;
+    }
+
+    @Unique
+    private void c2me$includeBounds(int[] bounds, int base) {
+        this.c2me$minX = Math.min(this.c2me$minX, bounds[base]);
+        this.c2me$maxX = Math.max(this.c2me$maxX, bounds[base + 1]);
+        this.c2me$minY = Math.min(this.c2me$minY, bounds[base + 2]);
+        this.c2me$maxY = Math.max(this.c2me$maxY, bounds[base + 3]);
+        this.c2me$minZ = Math.min(this.c2me$minZ, bounds[base + 4]);
+        this.c2me$maxZ = Math.max(this.c2me$maxZ, bounds[base + 5]);
+        this.c2me$hasInfluence = true;
+    }
+
+    @Unique
+    private static boolean c2me$isOutsideBounds(int[] bounds, int base, int x, int y, int z) {
+        return x < bounds[base] || x > bounds[base + 1]
+                || y < bounds[base + 2] || y > bounds[base + 3]
+                || z < bounds[base + 4] || z > bounds[base + 5];
     }
 
 }

--- a/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkGenerator.java
+++ b/c2me-rewrites-chunk-system/src/main/java/com/ishland/c2me/rewrites/chunksystem/mixin/MixinChunkGenerator.java
@@ -1,19 +1,48 @@
 package com.ishland.c2me.rewrites.chunksystem.mixin;
 
 import com.ishland.c2me.base.common.util.InvokingExecutorService;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.registry.Registry;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.structure.Structure;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
 
 @Mixin(ChunkGenerator.class)
-public class MixinChunkGenerator {
+public abstract class MixinChunkGenerator {
+
+    @Unique
+    private final ConcurrentHashMap<Registry<Structure>, Object> c2me$structuresByStepCache = new ConcurrentHashMap<>();
 
     @Redirect(method = "populateBiomes", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;getMainWorkerExecutor()Ljava/util/concurrent/ExecutorService;"))
     private ExecutorService redirectBiomeExecutor() {
         return InvokingExecutorService.INSTANCE;
     }
 
+    // vanilla re-groups the entire structure registry by generation step for every generated
+    // chunk; the result only depends on the registry, so compute it once and reuse it.
+    // the cached map is read-only after construction and safe for concurrent readers.
+    // require = 0: if another mod replaces generateFeatures, this cache silently backs off.
+    @WrapOperation(
+            method = "generateFeatures",
+            at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"),
+            require = 0
+    )
+    private Object cacheStructuresByStep(Stream<?> instance, Collector<?, ?, ?> collector, Operation<Object> original, @Local Registry<Structure> registry) {
+        Object cached = this.c2me$structuresByStepCache.get(registry);
+        if (cached == null) {
+            cached = original.call(instance, collector);
+            this.c2me$structuresByStepCache.putIfAbsent(registry, cached);
+        }
+        return cached;
+    }
 }


### PR DESCRIPTION
**Principle.** `StructureWeightSampler` precomputes a per-piece/junction influence AABB (each box expanded by the support radius of its terrain-adjustment kernel) plus a chunk-level union box, so density samples outside every influence volume return `0` without iterating pieces. `ChunkGenerator.generateFeatures` caches the per-registry "structures grouped by generation step" map with a single `@WrapOperation`, instead of re-grouping the whole registry on every generated chunk.