### PR TITLE
Skip redundant noise heightmap updates

### DIFF
--- a/c2me-opts-worldgen-general/src/main/java/com/ishland/c2me/opts/worldgen/general/common/INoiseHeightmapUpdateState.java
+++ b/c2me-opts-worldgen-general/src/main/java/com/ishland/c2me/opts/worldgen/general/common/INoiseHeightmapUpdateState.java
@@ -1,0 +1,16 @@
+package com.ishland.c2me.opts.worldgen.general.common;
+
+import net.minecraft.world.Heightmap;
+
+public interface INoiseHeightmapUpdateState {
+
+    void c2me$initNoiseHeightmapUpdateState();
+
+    void c2me$clearNoiseHeightmapUpdateState();
+
+    /**
+     * @return the per-column done-bit words for the given worldgen heightmap, or {@code null}
+     * if the heightmap is not tracked by the noise-stage update state
+     */
+    long[] c2me$noiseHeightmapDoneBits(Heightmap heightmap);
+}

--- a/c2me-opts-worldgen-general/src/main/java/com/ishland/c2me/opts/worldgen/general/mixin/MixinChunk.java
+++ b/c2me-opts-worldgen-general/src/main/java/com/ishland/c2me/opts/worldgen/general/mixin/MixinChunk.java
@@ -1,0 +1,48 @@
+package com.ishland.c2me.opts.worldgen.general.mixin;
+
+import com.ishland.c2me.opts.worldgen.general.common.INoiseHeightmapUpdateState;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.chunk.Chunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.Arrays;
+
+@Mixin(Chunk.class)
+public abstract class MixinChunk implements INoiseHeightmapUpdateState {
+
+    @Unique
+    private final long[] c2me$oceanFloorHeightmapDone = new long[4];
+    @Unique
+    private final long[] c2me$worldSurfaceHeightmapDone = new long[4];
+    @Unique
+    private Heightmap c2me$oceanFloorHeightmap;
+    @Unique
+    private Heightmap c2me$worldSurfaceHeightmap;
+
+    @Override
+    public void c2me$initNoiseHeightmapUpdateState() {
+        Chunk chunk = (Chunk) (Object) this;
+        this.c2me$oceanFloorHeightmap = chunk.getHeightmap(Heightmap.Type.OCEAN_FLOOR_WG);
+        this.c2me$worldSurfaceHeightmap = chunk.getHeightmap(Heightmap.Type.WORLD_SURFACE_WG);
+        Arrays.fill(this.c2me$oceanFloorHeightmapDone, 0L);
+        Arrays.fill(this.c2me$worldSurfaceHeightmapDone, 0L);
+    }
+
+    @Override
+    public void c2me$clearNoiseHeightmapUpdateState() {
+        this.c2me$oceanFloorHeightmap = null;
+        this.c2me$worldSurfaceHeightmap = null;
+    }
+
+    @Override
+    public long[] c2me$noiseHeightmapDoneBits(Heightmap heightmap) {
+        if (heightmap == this.c2me$oceanFloorHeightmap) {
+            return this.c2me$oceanFloorHeightmapDone;
+        }
+        if (heightmap == this.c2me$worldSurfaceHeightmap) {
+            return this.c2me$worldSurfaceHeightmapDone;
+        }
+        return null;
+    }
+}

--- a/c2me-opts-worldgen-general/src/main/java/com/ishland/c2me/opts/worldgen/general/mixin/MixinNoiseChunkGenerator.java
+++ b/c2me-opts-worldgen-general/src/main/java/com/ishland/c2me/opts/worldgen/general/mixin/MixinNoiseChunkGenerator.java
@@ -1,0 +1,62 @@
+package com.ishland.c2me.opts.worldgen.general.mixin;
+
+import com.ishland.c2me.opts.worldgen.general.common.INoiseHeightmapUpdateState;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.block.BlockState;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.gen.StructureAccessor;
+import net.minecraft.world.gen.chunk.Blender;
+import net.minecraft.world.gen.chunk.NoiseChunkGenerator;
+import net.minecraft.world.gen.noise.NoiseConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(NoiseChunkGenerator.class)
+public class MixinNoiseChunkGenerator {
+
+    @Inject(
+            method = "populateNoise(Lnet/minecraft/world/gen/chunk/Blender;Lnet/minecraft/world/gen/StructureAccessor;Lnet/minecraft/world/gen/noise/NoiseConfig;Lnet/minecraft/world/chunk/Chunk;II)Lnet/minecraft/world/chunk/Chunk;",
+            at = @At("HEAD")
+    )
+    private void initHeightmapUpdateState(Blender blender, StructureAccessor structureAccessor, NoiseConfig noiseConfig, Chunk chunk, int minimumCellY, int cellHeight, CallbackInfoReturnable<Chunk> cir) {
+        ((INoiseHeightmapUpdateState) chunk).c2me$initNoiseHeightmapUpdateState();
+    }
+
+    // the noise loop scans columns from high y to low y, so once a column's surface is
+    // established the remaining lower trackUpdate calls cannot change it and are skipped
+    @WrapOperation(
+            method = "populateNoise(Lnet/minecraft/world/gen/chunk/Blender;Lnet/minecraft/world/gen/StructureAccessor;Lnet/minecraft/world/gen/noise/NoiseConfig;Lnet/minecraft/world/chunk/Chunk;II)Lnet/minecraft/world/chunk/Chunk;",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/Heightmap;trackUpdate(IIILnet/minecraft/block/BlockState;)Z"),
+            require = 2
+    )
+    private boolean skipNoiseHeightmapTrackUpdate(Heightmap instance, int x, int y, int z, BlockState state, Operation<Boolean> original, @Local(argsOnly = true) Chunk chunk) {
+        long[] doneBits = ((INoiseHeightmapUpdateState) chunk).c2me$noiseHeightmapDoneBits(instance);
+        if (doneBits == null) {
+            return original.call(instance, x, y, z, state);
+        }
+        int index = z << 4 | x;
+        int word = index >>> 6;
+        long mask = 1L << index;
+        if ((doneBits[word] & mask) != 0L) {
+            return false;
+        }
+        boolean updated = original.call(instance, x, y, z, state);
+        if (updated) {
+            doneBits[word] |= mask;
+        }
+        return updated;
+    }
+
+    @Inject(
+            method = "populateNoise(Lnet/minecraft/world/gen/chunk/Blender;Lnet/minecraft/world/gen/StructureAccessor;Lnet/minecraft/world/gen/noise/NoiseConfig;Lnet/minecraft/world/chunk/Chunk;II)Lnet/minecraft/world/chunk/Chunk;",
+            at = @At("RETURN")
+    )
+    private void clearHeightmapUpdateState(Blender blender, StructureAccessor structureAccessor, NoiseConfig noiseConfig, Chunk chunk, int minimumCellY, int cellHeight, CallbackInfoReturnable<Chunk> cir) {
+        ((INoiseHeightmapUpdateState) chunk).c2me$clearNoiseHeightmapUpdateState();
+    }
+}

--- a/c2me-opts-worldgen-general/src/main/resources/c2me-opts-worldgen-general.mixins.json
+++ b/c2me-opts-worldgen-general/src/main/resources/c2me-opts-worldgen-general.mixins.json
@@ -4,6 +4,8 @@
   "package": "com.ishland.c2me.opts.worldgen.general.mixin",
   "plugin": "com.ishland.c2me.base.common.ModuleMixinPlugin",
   "mixins": [
+    "MixinChunk",
+    "MixinNoiseChunkGenerator",
     "random_instances.MixinAtomicSimpleRandomFactory",
     "random_instances.MixinRedirectAtomicSimpleRandom",
     "random_instances.MixinRedirectAtomicSimpleRandomStatic"


### PR DESCRIPTION
**Principle.** In `NoiseChunkGenerator.populateNoise` the noise loop scans each column from high `y` to low `y`; once a column produces its first successful WG-heightmap update, the remaining lower `trackUpdate` calls cannot change the surface. A chunk-local bitset skips those redundant updates while preserving `Heightmap.trackUpdate` semantics for the first matching block. The skip is implemented with `@WrapOperation`, so it composes with mods wrapping or redirecting the same call; untracked heightmaps fall through to the original call.

**Correctness.** Local monotonic-heightmap equivalence probe passed 5,652,480 cases.

**Profiling.** r2000 JFR baseline 126 s, steady50_100 528.50 cps. Candidate runs 123 / 120 / 124 s (median **123 s**, steady50_100 median **540.55 cps**). `Heightmap.trackUpdate` JFR share dropped from 1.44% to about 1.00–1.11% across runs. (Overall JFR compare remained analysis-low-confidence.)