### PR TITLE
Reuse DFC coordinate arrays via finally block

### DIFF
--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/SubCompiledDensityFunction.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/SubCompiledDensityFunction.java
@@ -88,7 +88,13 @@ public class SubCompiledDensityFunction implements DensityFunction {
                 z[i] = pos.blockZ();
             }
         }
-        this.multiMethod.evalMulti(densities, x, y, z, EvalType.from(applier), cache);
+        try {
+            this.multiMethod.evalMulti(densities, x, y, z, EvalType.from(applier), cache);
+        } finally {
+            cache.recycle(x);
+            cache.recycle(y);
+            cache.recycle(z);
+        }
     }
 
     @Override


### PR DESCRIPTION
**Principle (fix).** `SubCompiledDensityFunction.fill` borrows the x/y/z coordinate arrays from the `ArrayCache` but never returned them, so every call allocated three fresh arrays and the pool stayed empty. Recycle them in a `finally` block. The `vanillaInterface` path is left untouched, because those arrays are owned by the caller rather than borrowed from the cache.