### PR TITLE
Short-circuit FluidState.isEmpty for air in ChunkSection

### DIFF
--- a/c2me-opts-worldgen-general/src/main/java/com/ishland/c2me/opts/worldgen/general/mixin/MixinChunkSection.java
+++ b/c2me-opts-worldgen-general/src/main/java/com/ishland/c2me/opts/worldgen/general/mixin/MixinChunkSection.java
@@ -1,0 +1,30 @@
+package com.ishland.c2me.opts.worldgen.general.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.block.BlockState;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.world.chunk.ChunkSection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ChunkSection.class)
+public class MixinChunkSection {
+
+    @WrapOperation(
+            method = "setBlockState(IIILnet/minecraft/block/BlockState;Z)Lnet/minecraft/block/BlockState;",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/fluid/FluidState;isEmpty()Z", ordinal = 0)
+    )
+    private boolean skipOldAirFluidEmptyCheck(FluidState instance, Operation<Boolean> original, @Local(ordinal = 1) BlockState oldState) {
+        return oldState.isAir() || original.call(instance);
+    }
+
+    @WrapOperation(
+            method = "setBlockState(IIILnet/minecraft/block/BlockState;Z)Lnet/minecraft/block/BlockState;",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/fluid/FluidState;isEmpty()Z", ordinal = 1)
+    )
+    private boolean skipNewAirFluidEmptyCheck(FluidState instance, Operation<Boolean> original, @Local(argsOnly = true) BlockState newState) {
+        return newState.isAir() || original.call(instance);
+    }
+}

--- a/c2me-opts-worldgen-general/src/main/resources/c2me-opts-worldgen-general.mixins.json
+++ b/c2me-opts-worldgen-general/src/main/resources/c2me-opts-worldgen-general.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.ishland.c2me.opts.worldgen.general.mixin",
   "plugin": "com.ishland.c2me.base.common.ModuleMixinPlugin",
   "mixins": [
+    "MixinChunkSection",
     "random_instances.MixinAtomicSimpleRandomFactory",
     "random_instances.MixinRedirectAtomicSimpleRandom",
     "random_instances.MixinRedirectAtomicSimpleRandomStatic"


### PR DESCRIPTION
**Principle.** Short-circuit the `FluidState.isEmpty` checks in `ChunkSection.setBlockState` when the old/new block state is air, via `@WrapOperation`, skipping the meaningless fluid lookup on air cells. The injector composes with other mods wrapping the same call.