### PR TITLE
Optimize aquifer indexed water level lookup

### DIFF
--- a/c2me-opts-worldgen-vanilla/src/main/java/com/ishland/c2me/opts/worldgen/vanilla/mixin/aquifer/MixinAquiferSamplerImpl.java
+++ b/c2me-opts-worldgen-vanilla/src/main/java/com/ishland/c2me/opts/worldgen/vanilla/mixin/aquifer/MixinAquiferSamplerImpl.java
@@ -110,11 +110,11 @@ public abstract class MixinAquiferSamplerImpl {
     @Unique
     private int c2me$dist3;
     @Unique
-    private long c2me$pos1;
+    private int c2me$posIdx1;
     @Unique
-    private long c2me$pos2;
+    private int c2me$posIdx2;
     @Unique
-    private long c2me$pos3;
+    private int c2me$posIdx3;
 
     @Unique
     private double c2me$mutableDoubleThingy;
@@ -178,7 +178,7 @@ public abstract class MixinAquiferSamplerImpl {
 
     @Unique
     private @Nullable BlockState aquiferExtracted$applyPost(DensityFunction.NoisePos pos, double density, int j, int i, int k) {
-        AquiferSampler.FluidLevel fluidLevel2 = this.getWaterLevel(this.c2me$pos1);
+        AquiferSampler.FluidLevel fluidLevel2 = this.c2me$getWaterLevelIndexed(this.c2me$posIdx1);
         double d = maxDistance(this.c2me$dist1, this.c2me$dist2);
         BlockState blockState = fluidLevel2.getBlockState(j);
         if (d <= 0.0) {
@@ -190,7 +190,7 @@ public abstract class MixinAquiferSamplerImpl {
         } else {
 //            MutableDouble mutableDouble = new MutableDouble(Double.NaN); // 234MB/s alloc rate at 480 cps
             this.c2me$mutableDoubleThingy = Double.NaN;
-            AquiferSampler.FluidLevel fluidLevel3 = this.getWaterLevel(this.c2me$pos2);
+            AquiferSampler.FluidLevel fluidLevel3 = this.c2me$getWaterLevelIndexed(this.c2me$posIdx2);
             double e = d * this.c2me$calculateDensityModified(pos, fluidLevel2, fluidLevel3);
             if (density + e > 0.0) {
                 this.needsFluidTick = false;
@@ -203,7 +203,7 @@ public abstract class MixinAquiferSamplerImpl {
 
     @Unique
     private BlockState aquiferExtracted$getFinalBlockState(DensityFunction.NoisePos pos, double density, double d, AquiferSampler.FluidLevel fluidLevel2, AquiferSampler.FluidLevel fluidLevel3, BlockState blockState) {
-        AquiferSampler.FluidLevel fluidLevel4 = this.getWaterLevel(this.c2me$pos3);
+        AquiferSampler.FluidLevel fluidLevel4 = this.c2me$getWaterLevelIndexed(this.c2me$posIdx3);
         double f = maxDistance(this.c2me$dist1, this.c2me$dist3);
         if (aquiferExtracted$extractedCheckFG(pos, density, d, fluidLevel2, f, fluidLevel4)) return null;
 
@@ -235,9 +235,9 @@ public abstract class MixinAquiferSamplerImpl {
         int dist1 = Integer.MAX_VALUE;
         int dist2 = Integer.MAX_VALUE;
         int dist3 = Integer.MAX_VALUE;
-        long pos1 = 0;
-        long pos2 = 0;
-        long pos3 = 0;
+        int posIdx1 = 0;
+        int posIdx2 = 0;
+        int posIdx3 = 0;
 
         for (int offY = -1; offY <= 1; ++offY) {
             for (int offZ = 0; offZ <= 1; ++offZ) {
@@ -253,19 +253,19 @@ public abstract class MixinAquiferSamplerImpl {
 
                     // unexplainable branch prediction magic
                     if (dist3 >= dist) {
-                        pos3 = position;
+                        posIdx3 = posIdx;
                         dist3 = dist;
                     }
                     if (dist2 >= dist) {
-                        pos3 = pos2;
+                        posIdx3 = posIdx2;
                         dist3 = dist2;
-                        pos2 = position;
+                        posIdx2 = posIdx;
                         dist2 = dist;
                     }
                     if (dist1 >= dist) {
-                        pos2 = pos1;
+                        posIdx2 = posIdx1;
                         dist2 = dist1;
-                        pos1 = position;
+                        posIdx1 = posIdx;
                         dist1 = dist;
                     }
                 }
@@ -275,9 +275,24 @@ public abstract class MixinAquiferSamplerImpl {
         this.c2me$dist1 = dist1;
         this.c2me$dist2 = dist2;
         this.c2me$dist3 = dist3;
-        this.c2me$pos1 = pos1;
-        this.c2me$pos2 = pos2;
-        this.c2me$pos3 = pos3;
+        this.c2me$posIdx1 = posIdx1;
+        this.c2me$posIdx2 = posIdx2;
+        this.c2me$posIdx3 = posIdx3;
+    }
+
+    @Unique
+    private AquiferSampler.FluidLevel c2me$getWaterLevelIndexed(int index) {
+        AquiferSampler.FluidLevel fluidLevel = this.waterLevels[index];
+        if (fluidLevel != null) {
+            return fluidLevel;
+        }
+        long blockPosition = this.blockPositions[index];
+        int i = BlockPos.unpackLongX(blockPosition);
+        int j = BlockPos.unpackLongY(blockPosition);
+        int k = BlockPos.unpackLongZ(blockPosition);
+        AquiferSampler.FluidLevel fluidLevel2 = this.getFluidLevel(i, j, k);
+        this.waterLevels[index] = fluidLevel2;
+        return fluidLevel2;
     }
 
     /**


### PR DESCRIPTION
**Principle.** Replace the packed-long block positions kept for the nearest-three aquifer candidates with int indices into the existing per-cell arrays, and resolve fluid levels lazily through an indexed lookup that caches into the vanilla `waterLevels` array. This removes repeated `BlockPos` packing/unpacking on the aquifer hot path, and is the base for the candidate-cache and high-air PRs.