### PR TITLE
Optimize aquifer candidate cell lookup

### DIFF
--- a/c2me-opts-worldgen-vanilla/src/main/java/com/ishland/c2me/opts/worldgen/vanilla/mixin/aquifer/MixinAquiferSamplerImpl.java
+++ b/c2me-opts-worldgen-vanilla/src/main/java/com/ishland/c2me/opts/worldgen/vanilla/mixin/aquifer/MixinAquiferSamplerImpl.java
@@ -110,11 +110,11 @@ public abstract class MixinAquiferSamplerImpl {
     @Unique
     private int c2me$dist3;
     @Unique
-    private long c2me$pos1;
+    private int c2me$posIdx1;
     @Unique
-    private long c2me$pos2;
+    private int c2me$posIdx2;
     @Unique
-    private long c2me$pos3;
+    private int c2me$posIdx3;
 
     @Unique
     private double c2me$mutableDoubleThingy;
@@ -178,7 +178,7 @@ public abstract class MixinAquiferSamplerImpl {
 
     @Unique
     private @Nullable BlockState aquiferExtracted$applyPost(DensityFunction.NoisePos pos, double density, int j, int i, int k) {
-        AquiferSampler.FluidLevel fluidLevel2 = this.getWaterLevel(this.c2me$pos1);
+        AquiferSampler.FluidLevel fluidLevel2 = this.c2me$getWaterLevelIndexed(this.c2me$posIdx1);
         double d = maxDistance(this.c2me$dist1, this.c2me$dist2);
         BlockState blockState = fluidLevel2.getBlockState(j);
         if (d <= 0.0) {
@@ -190,7 +190,7 @@ public abstract class MixinAquiferSamplerImpl {
         } else {
 //            MutableDouble mutableDouble = new MutableDouble(Double.NaN); // 234MB/s alloc rate at 480 cps
             this.c2me$mutableDoubleThingy = Double.NaN;
-            AquiferSampler.FluidLevel fluidLevel3 = this.getWaterLevel(this.c2me$pos2);
+            AquiferSampler.FluidLevel fluidLevel3 = this.c2me$getWaterLevelIndexed(this.c2me$posIdx2);
             double e = d * this.c2me$calculateDensityModified(pos, fluidLevel2, fluidLevel3);
             if (density + e > 0.0) {
                 this.needsFluidTick = false;
@@ -203,7 +203,7 @@ public abstract class MixinAquiferSamplerImpl {
 
     @Unique
     private BlockState aquiferExtracted$getFinalBlockState(DensityFunction.NoisePos pos, double density, double d, AquiferSampler.FluidLevel fluidLevel2, AquiferSampler.FluidLevel fluidLevel3, BlockState blockState) {
-        AquiferSampler.FluidLevel fluidLevel4 = this.getWaterLevel(this.c2me$pos3);
+        AquiferSampler.FluidLevel fluidLevel4 = this.c2me$getWaterLevelIndexed(this.c2me$posIdx3);
         double f = maxDistance(this.c2me$dist1, this.c2me$dist3);
         if (aquiferExtracted$extractedCheckFG(pos, density, d, fluidLevel2, f, fluidLevel4)) return null;
 
@@ -235,9 +235,9 @@ public abstract class MixinAquiferSamplerImpl {
         int dist1 = Integer.MAX_VALUE;
         int dist2 = Integer.MAX_VALUE;
         int dist3 = Integer.MAX_VALUE;
-        long pos1 = 0;
-        long pos2 = 0;
-        long pos3 = 0;
+        int posIdx1 = 0;
+        int posIdx2 = 0;
+        int posIdx3 = 0;
 
         for (int offY = -1; offY <= 1; ++offY) {
             for (int offZ = 0; offZ <= 1; ++offZ) {
@@ -253,19 +253,19 @@ public abstract class MixinAquiferSamplerImpl {
 
                     // unexplainable branch prediction magic
                     if (dist3 >= dist) {
-                        pos3 = position;
+                        posIdx3 = posIdx;
                         dist3 = dist;
                     }
                     if (dist2 >= dist) {
-                        pos3 = pos2;
+                        posIdx3 = posIdx2;
                         dist3 = dist2;
-                        pos2 = position;
+                        posIdx2 = posIdx;
                         dist2 = dist;
                     }
                     if (dist1 >= dist) {
-                        pos2 = pos1;
+                        posIdx2 = posIdx1;
                         dist2 = dist1;
-                        pos1 = position;
+                        posIdx1 = posIdx;
                         dist1 = dist;
                     }
                 }
@@ -275,9 +275,24 @@ public abstract class MixinAquiferSamplerImpl {
         this.c2me$dist1 = dist1;
         this.c2me$dist2 = dist2;
         this.c2me$dist3 = dist3;
-        this.c2me$pos1 = pos1;
-        this.c2me$pos2 = pos2;
-        this.c2me$pos3 = pos3;
+        this.c2me$posIdx1 = posIdx1;
+        this.c2me$posIdx2 = posIdx2;
+        this.c2me$posIdx3 = posIdx3;
+    }
+
+    @Unique
+    private AquiferSampler.FluidLevel c2me$getWaterLevelIndexed(int index) {
+        AquiferSampler.FluidLevel fluidLevel = this.waterLevels[index];
+        if (fluidLevel != null) {
+            return fluidLevel;
+        }
+        long blockPosition = this.blockPositions[index];
+        int i = BlockPos.unpackLongX(blockPosition);
+        int j = BlockPos.unpackLongY(blockPosition);
+        int k = BlockPos.unpackLongZ(blockPosition);
+        AquiferSampler.FluidLevel fluidLevel2 = this.getFluidLevel(i, j, k);
+        this.waterLevels[index] = fluidLevel2;
+        return fluidLevel2;
     }
 
     /**

--- a/c2me-opts-worldgen-vanilla/src/main/java/com/ishland/c2me/opts/worldgen/vanilla/mixin/aquifer/MixinAquiferSamplerImpl.java
+++ b/c2me-opts-worldgen-vanilla/src/main/java/com/ishland/c2me/opts/worldgen/vanilla/mixin/aquifer/MixinAquiferSamplerImpl.java
@@ -27,6 +27,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(AquiferSampler.Impl.class)
 public abstract class MixinAquiferSamplerImpl {
 
+    @Unique
+    private static final int C2ME_AQUIFER_CANDIDATE_COUNT = 12;
+
     @Shadow
     @Final
     private int startX;
@@ -117,6 +120,23 @@ public abstract class MixinAquiferSamplerImpl {
     private int c2me$posIdx3;
 
     @Unique
+    private int c2me$lastGx = Integer.MIN_VALUE;
+    @Unique
+    private int c2me$lastGy;
+    @Unique
+    private int c2me$lastGz;
+    @Unique
+    private final int[] c2me$candidateX = new int[C2ME_AQUIFER_CANDIDATE_COUNT];
+    @Unique
+    private final int[] c2me$candidateY = new int[C2ME_AQUIFER_CANDIDATE_COUNT];
+    @Unique
+    private final int[] c2me$candidateZ = new int[C2ME_AQUIFER_CANDIDATE_COUNT];
+    @Unique
+    private final int[] c2me$candidateIdx = new int[C2ME_AQUIFER_CANDIDATE_COUNT];
+    @Unique
+    private final int[] c2me$candidateDist = new int[C2ME_AQUIFER_CANDIDATE_COUNT];
+
+    @Unique
     private double c2me$mutableDoubleThingy;
 
     @Inject(method = "<init>", at = @At("RETURN"))
@@ -196,6 +216,7 @@ public abstract class MixinAquiferSamplerImpl {
                 this.needsFluidTick = false;
                 return null;
             } else {
+                this.c2me$refreshThirdDistPosIdx();
                 return aquiferExtracted$getFinalBlockState(pos, density, d, fluidLevel2, fluidLevel3, blockState);
             }
         }
@@ -230,8 +251,67 @@ public abstract class MixinAquiferSamplerImpl {
     @NotNull
     private void aquiferExtracted$refreshDistPosIdx(int x, int y, int z) {
         int gx = (x - 5) >> 4;
-        int gy = Math.floorDiv(y + 1, 12);
+        int shiftedY = y + 1;
+        int gy = shiftedY >= 0 ? shiftedY / 12 : (shiftedY - 11) / 12;
         int gz = (z - 5) >> 4;
+        if (gx != this.c2me$lastGx || gy != this.c2me$lastGy || gz != this.c2me$lastGz) {
+            this.c2me$refillCandidates(gx, gy, gz);
+            this.c2me$lastGx = gx;
+            this.c2me$lastGy = gy;
+            this.c2me$lastGz = gz;
+        }
+
+        int dist1 = Integer.MAX_VALUE;
+        int dist2 = Integer.MAX_VALUE;
+        int posIdx1 = 0;
+        int posIdx2 = 0;
+
+        for (int i = 0; i < C2ME_AQUIFER_CANDIDATE_COUNT; i++) {
+            int dx = this.c2me$candidateX[i] - x;
+            int dy = this.c2me$candidateY[i] - y;
+            int dz = this.c2me$candidateZ[i] - z;
+            int dist = dx * dx + dy * dy + dz * dz;
+            this.c2me$candidateDist[i] = dist;
+            int posIdx = this.c2me$candidateIdx[i];
+
+            if (dist2 >= dist) {
+                posIdx2 = posIdx;
+                dist2 = dist;
+            }
+            if (dist1 >= dist) {
+                posIdx2 = posIdx1;
+                dist2 = dist1;
+                posIdx1 = posIdx;
+                dist1 = dist;
+            }
+        }
+
+        this.c2me$dist1 = dist1;
+        this.c2me$dist2 = dist2;
+        this.c2me$posIdx1 = posIdx1;
+        this.c2me$posIdx2 = posIdx2;
+    }
+
+    @Unique
+    private void c2me$refillCandidates(int gx, int gy, int gz) {
+        int candidate = 0;
+        for (int offY = -1; offY <= 1; ++offY) {
+            for (int offZ = 0; offZ <= 1; ++offZ) {
+                for (int offX = 0; offX <= 1; ++offX) {
+                    int posIdx = this.index(gx + offX, gy + offY, gz + offZ);
+                    long position = this.blockPositions[posIdx];
+                    this.c2me$candidateX[candidate] = BlockPos.unpackLongX(position);
+                    this.c2me$candidateY[candidate] = BlockPos.unpackLongY(position);
+                    this.c2me$candidateZ[candidate] = BlockPos.unpackLongZ(position);
+                    this.c2me$candidateIdx[candidate] = posIdx;
+                    candidate++;
+                }
+            }
+        }
+    }
+
+    @Unique
+    private void c2me$refreshThirdDistPosIdx() {
         int dist1 = Integer.MAX_VALUE;
         int dist2 = Integer.MAX_VALUE;
         int dist3 = Integer.MAX_VALUE;
@@ -239,36 +319,25 @@ public abstract class MixinAquiferSamplerImpl {
         int posIdx2 = 0;
         int posIdx3 = 0;
 
-        for (int offY = -1; offY <= 1; ++offY) {
-            for (int offZ = 0; offZ <= 1; ++offZ) {
-                for (int offX = 0; offX <= 1; ++offX) {
-                    int posIdx = this.index(gx + offX, gy + offY, gz + offZ);
+        for (int i = 0; i < C2ME_AQUIFER_CANDIDATE_COUNT; i++) {
+            int dist = this.c2me$candidateDist[i];
+            int posIdx = this.c2me$candidateIdx[i];
 
-                    long position = this.blockPositions[posIdx];
-
-                    int dx = BlockPos.unpackLongX(position) - x;
-                    int dy = BlockPos.unpackLongY(position) - y;
-                    int dz = BlockPos.unpackLongZ(position) - z;
-                    int dist = dx * dx + dy * dy + dz * dz;
-
-                    // unexplainable branch prediction magic
-                    if (dist3 >= dist) {
-                        posIdx3 = posIdx;
-                        dist3 = dist;
-                    }
-                    if (dist2 >= dist) {
-                        posIdx3 = posIdx2;
-                        dist3 = dist2;
-                        posIdx2 = posIdx;
-                        dist2 = dist;
-                    }
-                    if (dist1 >= dist) {
-                        posIdx2 = posIdx1;
-                        dist2 = dist1;
-                        posIdx1 = posIdx;
-                        dist1 = dist;
-                    }
-                }
+            if (dist3 >= dist) {
+                posIdx3 = posIdx;
+                dist3 = dist;
+            }
+            if (dist2 >= dist) {
+                posIdx3 = posIdx2;
+                dist3 = dist2;
+                posIdx2 = posIdx;
+                dist2 = dist;
+            }
+            if (dist1 >= dist) {
+                posIdx2 = posIdx1;
+                dist2 = dist1;
+                posIdx1 = posIdx;
+                dist1 = dist;
             }
         }
 


### PR DESCRIPTION
**Principle.** Cache the 12 aquifer candidate positions for the current grid cell and keep only the nearest-two distances on the hot path; replay the original top-three comparison order only when the final block-state path actually needs the third candidate, preserving tie behaviour while avoiding repeated index/unpack work on every sample. Also replace `Math.floorDiv(y + 1, 12)` in the grid-cell computation with an equivalent sign-branch division.

**Correctness.** Top-k equivalence probe passed 204,096 cases.

**Profiling.** r2000 JFR suite `goal1-task3-cell-cache` vs base: 119 / 131 / 123 s (median **123 s** vs 127 s baseline); steady50_100 cps median **546.09** vs 520.12;