### PR TITLE
Materialize DFC caches in dependency order

### DIFF
--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGen.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGen.java
@@ -32,6 +32,7 @@ import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
 import com.ishland.c2me.opts.dfc.common.ast.misc.RootNode;
 import com.ishland.c2me.opts.dfc.common.ast.misc.YClampedGradientNode;
 import com.ishland.c2me.opts.dfc.common.ast.opto.OptoPasses;
+import com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike;
 import com.ishland.c2me.opts.dfc.common.gen.GenDumper;
 import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefD;
 import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
@@ -132,6 +133,7 @@ public class BytecodeGen {
         genConstructor(genContext);
         genGetArgs(genContext);
         genNewInstance(genContext);
+        genSetCacheField(genContext);
 //        genFields(genContext);
 
 //        ListIterator<Object> iterator = args.listIterator();
@@ -275,6 +277,56 @@ public class BytecodeGen {
         m.visitLabel(end);
         m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
         m.visitLocalVariable("args", Type.getDescriptor(Object[].class), null, start, end, 1);
+        m.visitMaxs(0, 0);
+    }
+
+    private static void genSetCacheField(Context context) {
+        String descriptor = Type.getMethodDescriptor(Type.VOID_TYPE, Type.INT_TYPE, Type.getType(IFastCacheLike.class));
+        InstructionAdapter m = new InstructionAdapter(
+                new AnalyzerAdapter(
+                        context.className,
+                        Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
+                        "setCacheField",
+                        descriptor,
+                        context.classWriter.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL, "setCacheField", descriptor, null, null)
+                )
+        );
+        Label start = new Label();
+        Label invalidField = new Label();
+        Label end = new Label();
+        m.visitLabel(start);
+
+        List<Context.FieldRecord> cacheFields = context.args.values().stream()
+                .filter(field -> field.type() == IFastCacheLike.class)
+                .sorted(Comparator.comparingInt(Context.FieldRecord::ordinal))
+                .toList();
+        int[] keys = new int[cacheFields.size()];
+        Label[] labels = new Label[cacheFields.size()];
+        for (int i = 0; i < cacheFields.size(); i++) {
+            keys[i] = cacheFields.get(i).ordinal();
+            labels[i] = new Label();
+        }
+
+        m.load(1, Type.INT_TYPE);
+        m.visitLookupSwitchInsn(invalidField, keys, labels);
+        for (int i = 0; i < cacheFields.size(); i++) {
+            Context.FieldRecord field = cacheFields.get(i);
+            m.visitLabel(labels[i]);
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.load(2, InstructionAdapter.OBJECT_TYPE);
+            m.putfield(context.className, field.name(), Type.getDescriptor(IFastCacheLike.class));
+            m.areturn(Type.VOID_TYPE);
+        }
+
+        m.visitLabel(invalidField);
+        m.anew(Type.getType(IllegalArgumentException.class));
+        m.dup();
+        m.invokespecial(Type.getInternalName(IllegalArgumentException.class), "<init>", "()V", false);
+        m.athrow();
+        m.visitLabel(end);
+        m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
+        m.visitLocalVariable("fieldIndex", Type.INT_TYPE.getDescriptor(), null, start, end, 1);
+        m.visitLocalVariable("cacheLike", Type.getDescriptor(IFastCacheLike.class), null, start, end, 2);
         m.visitMaxs(0, 0);
     }
 

--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGen.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGen.java
@@ -43,7 +43,6 @@ import it.unimi.dsi.fastutil.objects.Object2ReferenceMap;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceMaps;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenCustomHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
-import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
 import net.minecraft.util.math.Spline;
@@ -67,6 +66,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.IntConsumer;
 
 public class BytecodeGen {
@@ -124,7 +124,7 @@ public class BytecodeGen {
 
         if (cached != null) {
             try {
-                return (CompiledEntry) cached.getConstructor(Object[].class).newInstance(new Object[]{args});
+                return (CompiledEntry) cached.getConstructor(Object[].class, Function.class).newInstance(new Object[]{args, Function.identity()});
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 throw new RuntimeException(e);
             }
@@ -133,7 +133,6 @@ public class BytecodeGen {
         genConstructor(genContext);
         genGetArgs(genContext);
         genNewInstance(genContext);
-        genSetCacheField(genContext);
 //        genFields(genContext);
 
 //        ListIterator<Object> iterator = args.listIterator();
@@ -150,7 +149,7 @@ public class BytecodeGen {
         Class<?> defined = defineClass(genContext.className, bytes);
         compilationCache.put(node, defined);
         try {
-            return (CompiledEntry) defined.getConstructor(Object[].class).newInstance(new Object[]{args});
+            return (CompiledEntry) defined.getConstructor(Object[].class, Function.class).newInstance(new Object[]{args, Function.identity()});
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
@@ -180,28 +179,37 @@ public class BytecodeGen {
         m.load(0, InstructionAdapter.OBJECT_TYPE);
         m.invokespecial(Type.getInternalName(Object.class), "<init>", Type.getMethodDescriptor(Type.VOID_TYPE), false);
 
+        // A cache transformer may eagerly evaluate its rebound delegate. Field ordinals are
+        // dependency-ordered so every field used by that delegate has already been assigned.
         for (Map.Entry<Object, Context.FieldRecord> entry : context.args.entrySet().stream().sorted(Comparator.comparingInt(o -> o.getValue().ordinal())).toList()) {
             String name = entry.getValue().name();
             Class<?> type = entry.getValue().type();
             int ordinal = entry.getValue().ordinal();
+            String postProcessingMethod = context.postProcessMethods.get(name);
 
             m.load(0, InstructionAdapter.OBJECT_TYPE);
-            m.load(1, InstructionAdapter.OBJECT_TYPE);
-            m.iconst(ordinal);
-            m.aload(InstructionAdapter.OBJECT_TYPE);
-            m.checkcast(Type.getType(type));
+            if (postProcessingMethod != null) {
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.iconst(ordinal);
+                m.aload(InstructionAdapter.OBJECT_TYPE);
+                m.checkcast(Type.getType(type));
+                m.load(2, InstructionAdapter.OBJECT_TYPE);
+                m.invokevirtual(context.className, postProcessingMethod, Context.POSTPROCESSING_DESC, false);
+            } else {
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.iconst(ordinal);
+                m.aload(InstructionAdapter.OBJECT_TYPE);
+                m.checkcast(Type.getType(type));
+            }
             m.putfield(context.className, name, Type.getDescriptor(type));
-        }
-
-        for (String postProcessingMethod : context.postProcessMethods) {
-            m.load(0, InstructionAdapter.OBJECT_TYPE);
-            m.invokevirtual(context.className, postProcessingMethod, Context.POSTPROCESSING_DESC, false);
         }
 
         m.areturn(Type.VOID_TYPE);
         m.visitLabel(end);
         m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
         m.visitLocalVariable("args", Type.getDescriptor(Object[].class), null, start, end, 1);
+        m.visitLocalVariable("cacheTransformer", Type.getDescriptor(Function.class), null, start, end, 2);
         m.visitMaxs(0, 0);
     }
 
@@ -254,11 +262,11 @@ public class BytecodeGen {
                         context.className,
                         Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
                         "newInstance",
-                        Type.getMethodDescriptor(Type.getType(CompiledEntry.class), Type.getType(Object[].class)),
+                        Type.getMethodDescriptor(Type.getType(CompiledEntry.class), Type.getType(Object[].class), Type.getType(Function.class)),
                         context.classWriter.visitMethod(
                                 Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
                                 "newInstance",
-                                Type.getMethodDescriptor(Type.getType(CompiledEntry.class), Type.getType(Object[].class)),
+                                Type.getMethodDescriptor(Type.getType(CompiledEntry.class), Type.getType(Object[].class), Type.getType(Function.class)),
                                 null,
                                 null
                         )
@@ -271,62 +279,14 @@ public class BytecodeGen {
         m.anew(Type.getType(context.classDesc));
         m.dup();
         m.load(1, InstructionAdapter.OBJECT_TYPE);
-        m.invokespecial(context.className, "<init>", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Object[].class)), false);
+        m.load(2, InstructionAdapter.OBJECT_TYPE);
+        m.invokespecial(context.className, "<init>", Context.CONSTRUCTOR_DESC, false);
         m.areturn(InstructionAdapter.OBJECT_TYPE);
 
         m.visitLabel(end);
         m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
         m.visitLocalVariable("args", Type.getDescriptor(Object[].class), null, start, end, 1);
-        m.visitMaxs(0, 0);
-    }
-
-    private static void genSetCacheField(Context context) {
-        String descriptor = Type.getMethodDescriptor(Type.VOID_TYPE, Type.INT_TYPE, Type.getType(IFastCacheLike.class));
-        InstructionAdapter m = new InstructionAdapter(
-                new AnalyzerAdapter(
-                        context.className,
-                        Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
-                        "setCacheField",
-                        descriptor,
-                        context.classWriter.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL, "setCacheField", descriptor, null, null)
-                )
-        );
-        Label start = new Label();
-        Label invalidField = new Label();
-        Label end = new Label();
-        m.visitLabel(start);
-
-        List<Context.FieldRecord> cacheFields = context.args.values().stream()
-                .filter(field -> field.type() == IFastCacheLike.class)
-                .sorted(Comparator.comparingInt(Context.FieldRecord::ordinal))
-                .toList();
-        int[] keys = new int[cacheFields.size()];
-        Label[] labels = new Label[cacheFields.size()];
-        for (int i = 0; i < cacheFields.size(); i++) {
-            keys[i] = cacheFields.get(i).ordinal();
-            labels[i] = new Label();
-        }
-
-        m.load(1, Type.INT_TYPE);
-        m.visitLookupSwitchInsn(invalidField, keys, labels);
-        for (int i = 0; i < cacheFields.size(); i++) {
-            Context.FieldRecord field = cacheFields.get(i);
-            m.visitLabel(labels[i]);
-            m.load(0, InstructionAdapter.OBJECT_TYPE);
-            m.load(2, InstructionAdapter.OBJECT_TYPE);
-            m.putfield(context.className, field.name(), Type.getDescriptor(IFastCacheLike.class));
-            m.areturn(Type.VOID_TYPE);
-        }
-
-        m.visitLabel(invalidField);
-        m.anew(Type.getType(IllegalArgumentException.class));
-        m.dup();
-        m.invokespecial(Type.getInternalName(IllegalArgumentException.class), "<init>", "()V", false);
-        m.athrow();
-        m.visitLabel(end);
-        m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
-        m.visitLocalVariable("fieldIndex", Type.INT_TYPE.getDescriptor(), null, start, end, 1);
-        m.visitLocalVariable("cacheLike", Type.getDescriptor(IFastCacheLike.class), null, start, end, 2);
+        m.visitLocalVariable("cacheTransformer", Type.getDescriptor(Function.class), null, start, end, 2);
         m.visitMaxs(0, 0);
     }
 
@@ -367,8 +327,8 @@ public class BytecodeGen {
     public static class Context {
         public static final String SINGLE_DESC = Type.getMethodDescriptor(Type.getType(double.class), Type.getType(int.class), Type.getType(int.class), Type.getType(int.class), Type.getType(EvalType.class), Type.getType(DfcObjectCache.class));
         public static final String MULTI_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(EvalType.class), Type.getType(DfcObjectCache.class));
-        public static final String POSTPROCESSING_DESC = Type.getMethodDescriptor(Type.VOID_TYPE);
-        public static final String CONSTRUCTOR_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Object[].class));
+        public static final String POSTPROCESSING_DESC = Type.getMethodDescriptor(Type.getType(IFastCacheLike.class), Type.getType(IFastCacheLike.class), Type.getType(Function.class));
+        public static final String CONSTRUCTOR_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Object[].class), Type.getType(Function.class));
         public final ClassWriter classWriter;
         public final String className;
         public final String classDesc;
@@ -377,7 +337,7 @@ public class BytecodeGen {
         private final Object2ReferenceOpenHashMap<AstNode, String> multiMethods = new Object2ReferenceOpenHashMap<>();
         private final Object2ReferenceOpenHashMap<Spline<DensityFunctionTypes.Spline.DensityFunctionWrapper>, String> splineMethods = new Object2ReferenceOpenHashMap<>();
         private final Object2ReferenceOpenHashMap<Spline<DensityFunctionTypes.Spline.DensityFunctionWrapper>, String> splineMethodsCache1 = new Object2ReferenceOpenHashMap<>();
-        private final ObjectLinkedOpenHashSet<String> postProcessMethods = new ObjectLinkedOpenHashSet<>();
+        private final Object2ReferenceOpenHashMap<String, String> postProcessMethods = new Object2ReferenceOpenHashMap<>();
         private final Reference2ObjectOpenHashMap<Object, FieldRecord> args = new Reference2ObjectOpenHashMap<>();
 
         public Context(ClassWriter classWriter, String className) {
@@ -600,7 +560,7 @@ public class BytecodeGen {
             }
             int size = this.args.size();
             String name = String.format("field_%d", size);
-            classWriter.visitField(Opcodes.ACC_PRIVATE, name, Type.getDescriptor(type), null, null);
+            classWriter.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL, name, Type.getDescriptor(type), null, null);
             this.args.put(data, new FieldRecord(name, size, type));
             return name;
         }
@@ -638,8 +598,8 @@ public class BytecodeGen {
             });
         }
 
-        public void genPostprocessingMethod(String name, Consumer<InstructionAdapter> generator) {
-            if (this.postProcessMethods.contains(name)) {
+        public void genPostprocessingMethod(String fieldName, String name, Consumer<InstructionAdapter> generator) {
+            if (this.postProcessMethods.containsKey(fieldName)) {
                 return;
             }
             InstructionAdapter adapter = new InstructionAdapter(
@@ -664,7 +624,9 @@ public class BytecodeGen {
             adapter.visitLabel(end);
             adapter.visitMaxs(0, 0);
             adapter.visitLocalVariable("this", this.classDesc, null, start, end, 0);
-            this.postProcessMethods.add(name);
+            adapter.visitLocalVariable("cacheLike", Type.getDescriptor(IFastCacheLike.class), null, start, end, 1);
+            adapter.visitLocalVariable("cacheTransformer", Type.getDescriptor(Function.class), null, start, end, 2);
+            this.postProcessMethods.put(fieldName, name);
         }
 
         public static interface LocalVarConsumer {

--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledDensityFunction.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledDensityFunction.java
@@ -77,19 +77,28 @@ public class CompiledDensityFunction extends SubCompiledDensityFunction {
             }
         }
 
+        CompiledEntry stagingEntry = null;
+        Object[] stagingArgs = null;
         for (int i = 0; i < args.length; i ++) {
             Object next = args[i];
-            if (next instanceof IFastCacheLike cacheLike) {
+            if (next instanceof IFastCacheLike) {
+                if (stagingEntry == null) {
+                    stagingEntry = this.compiledEntry.newInstance(args);
+                    stagingArgs = stagingEntry.getArgs();
+                }
+                IFastCacheLike cacheLike = (IFastCacheLike) stagingArgs[i];
                 DensityFunction applied = visitor.apply(cacheLike);
+                IFastCacheLike newCacheLike;
                 if (applied == cacheLike.c2me$getDelegate()) {
-                    args[i] = null; // cache removed
-                    modified = true;
-                } else if (applied instanceof IFastCacheLike newCacheLike) {
-                    args[i] = newCacheLike;
-                    modified = true;
+                    newCacheLike = null; // cache removed
+                } else if (applied instanceof IFastCacheLike transformedCacheLike) {
+                    newCacheLike = transformedCacheLike;
                 } else {
                     throw new UnsupportedOperationException("Unsupported transformation on Wrapping node");
                 }
+                args[i] = newCacheLike;
+                stagingEntry.setCacheField(i, newCacheLike);
+                modified = true;
             }
         }
 
@@ -101,7 +110,8 @@ public class CompiledDensityFunction extends SubCompiledDensityFunction {
             modified = true;
         }
         if (modified) {
-            return new CompiledDensityFunction(this.compiledEntry.newInstance(args), fallback);
+            CompiledEntry newEntry = stagingEntry != null ? stagingEntry : this.compiledEntry.newInstance(args);
+            return new CompiledDensityFunction(newEntry, fallback);
         } else {
             return this;
         }
@@ -138,19 +148,28 @@ public class CompiledDensityFunction extends SubCompiledDensityFunction {
             }
         }
 
+        CompiledEntry stagingEntry = null;
+        Object[] stagingArgs = null;
         for (int i = 0; i < args.length; i ++) {
             Object next = args[i];
-            if (next instanceof IFastCacheLike cacheLike) {
+            if (next instanceof IFastCacheLike) {
+                if (stagingEntry == null) {
+                    stagingEntry = this.compiledEntry.newInstance(args);
+                    stagingArgs = stagingEntry.getArgs();
+                }
+                IFastCacheLike cacheLike = (IFastCacheLike) stagingArgs[i];
                 DensityFunction applied = visitor.apply(cacheLike);
+                IFastCacheLike newCacheLike;
                 if (applied == cacheLike.c2me$getDelegate()) {
-                    args[i] = null; // cache removed
-                    modified = true;
-                } else if (applied instanceof IFastCacheLike newCacheLike) {
-                    args[i] = newCacheLike;
-                    modified = true;
+                    newCacheLike = null; // cache removed
+                } else if (applied instanceof IFastCacheLike transformedCacheLike) {
+                    newCacheLike = transformedCacheLike;
                 } else {
                     throw new UnsupportedOperationException("Unsupported transformation on Wrapping node");
                 }
+                args[i] = newCacheLike;
+                stagingEntry.setCacheField(i, newCacheLike);
+                modified = true;
             }
         }
 
@@ -162,7 +181,8 @@ public class CompiledDensityFunction extends SubCompiledDensityFunction {
             modified = true;
         }
         if (modified) {
-            return new CompiledDensityFunction(this.compiledEntry.newInstance(args), fallback);
+            CompiledEntry newEntry = stagingEntry != null ? stagingEntry : this.compiledEntry.newInstance(args);
+            return new CompiledDensityFunction(newEntry, fallback);
         } else {
             return this;
         }

--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledDensityFunction.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledDensityFunction.java
@@ -30,6 +30,7 @@ import com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike;
 import net.minecraft.world.gen.densityfunction.DensityFunction;
 
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class CompiledDensityFunction extends SubCompiledDensityFunction {
@@ -48,95 +49,52 @@ public class CompiledDensityFunction extends SubCompiledDensityFunction {
 
     @Override
     public DensityFunction applyInternal(DensityFunctionVisitor visitor) {
-        if (visitor instanceof IBlendingAwareVisitor blendingAwareVisitor && blendingAwareVisitor.c2me$isBlendingEnabled()) {
-            DensityFunction fallback1 = this.getFallback();
-            if (fallback1 == null) {
-                throw new IllegalStateException("blendingFallback is no more");
-            }
-            return visitor.apply(fallback1);
-        }
-        boolean modified = false;
-        Object[] args = this.compiledEntry.getArgs();
-        for (int i = 0; i < args.length; i ++) {
-            Object next = args[i];
-            if (next instanceof DensityFunction df) {
-                if (!(df instanceof IFastCacheLike)) {
-                    DensityFunction applied = visitor.apply(df);
-                    if (df != applied) {
-                        args[i] = applied;
-                        modified = true;
-                    }
-                }
-            }
-            if (next instanceof Noise noise) {
-                Noise applied = visitor.apply(noise);
-                if (noise != applied) {
-                    args[i] = applied;
-                    modified = true;
-                }
-            }
-        }
-
-        CompiledEntry stagingEntry = null;
-        Object[] stagingArgs = null;
-        for (int i = 0; i < args.length; i ++) {
-            Object next = args[i];
-            if (next instanceof IFastCacheLike) {
-                if (stagingEntry == null) {
-                    stagingEntry = this.compiledEntry.newInstance(args);
-                    stagingArgs = stagingEntry.getArgs();
-                }
-                IFastCacheLike cacheLike = (IFastCacheLike) stagingArgs[i];
-                DensityFunction applied = visitor.apply(cacheLike);
-                IFastCacheLike newCacheLike;
-                if (applied == cacheLike.c2me$getDelegate()) {
-                    newCacheLike = null; // cache removed
-                } else if (applied instanceof IFastCacheLike transformedCacheLike) {
-                    newCacheLike = transformedCacheLike;
-                } else {
-                    throw new UnsupportedOperationException("Unsupported transformation on Wrapping node");
-                }
-                args[i] = newCacheLike;
-                stagingEntry.setCacheField(i, newCacheLike);
-                modified = true;
-            }
-        }
-
-        Supplier<DensityFunction> fallback = this.blendingFallback != null ? Suppliers.memoize(() -> {
-            DensityFunction densityFunction = this.blendingFallback.get();
-            return densityFunction != null ? visitor.apply(densityFunction) : null;
-        }) : null;
-        if (fallback != this.blendingFallback) {
-            modified = true;
-        }
-        if (modified) {
-            CompiledEntry newEntry = stagingEntry != null ? stagingEntry : this.compiledEntry.newInstance(args);
-            return new CompiledDensityFunction(newEntry, fallback);
-        } else {
-            return this;
-        }
+        return this.applyVisitor(visitor, visitor::apply);
     }
 
     @Override
     public DensityFunction apply(DensityFunctionVisitor visitor) {
+        return this.applyVisitor(visitor, densityFunction -> densityFunction.apply(visitor));
+    }
+
+    private DensityFunction applyVisitor(DensityFunctionVisitor visitor, Function<DensityFunction, DensityFunction> densityTransformer) {
         if (visitor instanceof IBlendingAwareVisitor blendingAwareVisitor && blendingAwareVisitor.c2me$isBlendingEnabled()) {
             DensityFunction fallback1 = this.getFallback();
             if (fallback1 == null) {
                 throw new IllegalStateException("blendingFallback is no more");
             }
-            return fallback1.apply(visitor);
+            return densityTransformer.apply(fallback1);
         }
-        boolean modified = false;
+
         Object[] args = this.compiledEntry.getArgs();
+        boolean modified = transformArgs(args, visitor, densityTransformer);
+
+        Supplier<DensityFunction> fallback = this.blendingFallback != null ? Suppliers.memoize(() -> {
+            DensityFunction densityFunction = this.blendingFallback.get();
+            return densityFunction != null ? densityTransformer.apply(densityFunction) : null;
+        }) : null;
+        if (fallback != this.blendingFallback) {
+            modified = true;
+        }
+        if (!modified) {
+            return this;
+        }
+
+        CompiledEntry newEntry = this.compiledEntry.newInstance(args, cacheLike -> transformCache(visitor, cacheLike));
+        return new CompiledDensityFunction(newEntry, fallback);
+    }
+
+    private static boolean transformArgs(Object[] args, DensityFunctionVisitor visitor, Function<DensityFunction, DensityFunction> densityTransformer) {
+        boolean modified = false;
         for (int i = 0; i < args.length; i ++) {
             Object next = args[i];
-            if (next instanceof DensityFunction df) {
-                if (!(df instanceof IFastCacheLike)) {
-                    DensityFunction applied = df.apply(visitor);
-                    if (df != applied) {
-                        args[i] = applied;
-                        modified = true;
-                    }
+            if (next instanceof IFastCacheLike) {
+                modified = true;
+            } else if (next instanceof DensityFunction df) {
+                DensityFunction applied = densityTransformer.apply(df);
+                if (df != applied) {
+                    args[i] = applied;
+                    modified = true;
                 }
             }
             if (next instanceof Noise noise) {
@@ -147,44 +105,17 @@ public class CompiledDensityFunction extends SubCompiledDensityFunction {
                 }
             }
         }
+        return modified;
+    }
 
-        CompiledEntry stagingEntry = null;
-        Object[] stagingArgs = null;
-        for (int i = 0; i < args.length; i ++) {
-            Object next = args[i];
-            if (next instanceof IFastCacheLike) {
-                if (stagingEntry == null) {
-                    stagingEntry = this.compiledEntry.newInstance(args);
-                    stagingArgs = stagingEntry.getArgs();
-                }
-                IFastCacheLike cacheLike = (IFastCacheLike) stagingArgs[i];
-                DensityFunction applied = visitor.apply(cacheLike);
-                IFastCacheLike newCacheLike;
-                if (applied == cacheLike.c2me$getDelegate()) {
-                    newCacheLike = null; // cache removed
-                } else if (applied instanceof IFastCacheLike transformedCacheLike) {
-                    newCacheLike = transformedCacheLike;
-                } else {
-                    throw new UnsupportedOperationException("Unsupported transformation on Wrapping node");
-                }
-                args[i] = newCacheLike;
-                stagingEntry.setCacheField(i, newCacheLike);
-                modified = true;
-            }
-        }
-
-        Supplier<DensityFunction> fallback = this.blendingFallback != null ? Suppliers.memoize(() -> {
-            DensityFunction densityFunction = this.blendingFallback.get();
-            return densityFunction != null ? densityFunction.apply(visitor) : null;
-        }) : null;
-        if (fallback != this.blendingFallback) {
-            modified = true;
-        }
-        if (modified) {
-            CompiledEntry newEntry = stagingEntry != null ? stagingEntry : this.compiledEntry.newInstance(args);
-            return new CompiledDensityFunction(newEntry, fallback);
+    private static IFastCacheLike transformCache(DensityFunctionVisitor visitor, IFastCacheLike cacheLike) {
+        DensityFunction applied = visitor.apply(cacheLike);
+        if (applied == cacheLike.c2me$getDelegate()) {
+            return null; // cache removed
+        } else if (applied instanceof IFastCacheLike transformedCacheLike) {
+            return transformedCacheLike;
         } else {
-            return this;
+            throw new UnsupportedOperationException("Unsupported transformation on Wrapping node");
         }
     }
 

--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledEntry.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledEntry.java
@@ -28,15 +28,15 @@ import com.ishland.c2me.opts.dfc.common.ast.EvalType;
 import com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike;
 import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
 
+import java.util.function.Function;
+
 public interface CompiledEntry extends ISingleMethod, IMultiMethod {
 
     double evalSingle(int x, int y, int z, EvalType type, DfcObjectCache dfcObjectCache);
 
     void evalMulti(double[] res, int[] x, int[] y, int[] z, EvalType type, DfcObjectCache dfcObjectCache);
 
-    CompiledEntry newInstance(Object[] args);
-
-    void setCacheField(int fieldIndex, IFastCacheLike cacheLike);
+    CompiledEntry newInstance(Object[] args, Function<IFastCacheLike, IFastCacheLike> cacheTransformer);
 
     Object[] getArgs();
 

--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledEntry.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledEntry.java
@@ -25,6 +25,7 @@
 package com.ishland.c2me.opts.dfc.common.gen.jvm;
 
 import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike;
 import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
 
 public interface CompiledEntry extends ISingleMethod, IMultiMethod {
@@ -34,6 +35,8 @@ public interface CompiledEntry extends ISingleMethod, IMultiMethod {
     void evalMulti(double[] res, int[] x, int[] y, int[] z, EvalType type, DfcObjectCache dfcObjectCache);
 
     CompiledEntry newInstance(Object[] args);
+
+    void setCacheField(int fieldIndex, IFastCacheLike cacheLike);
 
     Object[] getArgs();
 

--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/CacheLikeNodeBytecodeEmitter.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/CacheLikeNodeBytecodeEmitter.java
@@ -32,7 +32,6 @@ import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
 import com.ishland.c2me.opts.dfc.common.gen.jvm.IMultiMethod;
 import com.ishland.c2me.opts.dfc.common.gen.jvm.ISingleMethod;
 import com.ishland.c2me.opts.dfc.common.gen.jvm.SubCompiledDensityFunction;
-import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
 import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefD;
 import net.minecraft.world.gen.densityfunction.DensityFunction;
 import org.objectweb.asm.Handle;
@@ -50,8 +49,8 @@ public class CacheLikeNodeBytecodeEmitter implements BytecodeEmitter<CacheLikeNo
     @Override
     public void doBytecodeGenSingle(CacheLikeNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
         ValuesMethodDefD delegateMethod = context.newSingleMethod(node.getDelegate());
-        String cacheLikeField = context.newField(IFastCacheLike.class, node.getCacheLike());
-        genPostprocessingMethod(node, context, cacheLikeField);
+
+        String cacheLikeField = registerCache(node, context);
 
         int eval = localVarConsumer.createLocalVariable("eval", Type.DOUBLE_TYPE.getDescriptor());
 
@@ -100,9 +99,8 @@ public class CacheLikeNodeBytecodeEmitter implements BytecodeEmitter<CacheLikeNo
     @Override
     public void doBytecodeGenMulti(CacheLikeNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
         ValuesMethodDefD delegateMethod = context.newMultiMethod(node.getDelegate());
-        String cacheLikeField = context.newField(IFastCacheLike.class, node.getCacheLike());
 
-        genPostprocessingMethod(node, context, cacheLikeField);
+        String cacheLikeField = registerCache(node, context);
 
         Label cacheExists = new Label();
         Label cacheMiss = new Label();
@@ -138,10 +136,14 @@ public class CacheLikeNodeBytecodeEmitter implements BytecodeEmitter<CacheLikeNo
         m.areturn(Type.VOID_TYPE);
     }
 
-    private void genPostprocessingMethod(CacheLikeNode node, BytecodeGen.Context context, String cacheLikeField) {
-        String methodName = String.format("postProcessing_%s", cacheLikeField);
+    private String registerCache(CacheLikeNode node, BytecodeGen.Context context) {
+        // put here to ensure init order
         String delegateSingle = context.newSingleMethodUnoptimized(node.getDelegate());
         String delegateMulti = context.newMultiMethodUnoptimized(node.getDelegate());
+
+        String cacheLikeField = context.newField(IFastCacheLike.class, node.getCacheLike());
+        String methodName = String.format("postProcessing_%s", cacheLikeField);
+
         context.genPostprocessingMethod(methodName, m -> {
             Label cacheExists = new Label();
 
@@ -235,5 +237,6 @@ public class CacheLikeNodeBytecodeEmitter implements BytecodeEmitter<CacheLikeNo
 
             m.areturn(Type.VOID_TYPE);
         });
+        return cacheLikeField;
     }
 }

--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/CacheLikeNodeBytecodeEmitter.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/CacheLikeNodeBytecodeEmitter.java
@@ -40,6 +40,8 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.InstructionAdapter;
 
+import java.util.function.Function;
+
 public class CacheLikeNodeBytecodeEmitter implements BytecodeEmitter<CacheLikeNode> {
     public static final CacheLikeNodeBytecodeEmitter INSTANCE = new CacheLikeNodeBytecodeEmitter();
 
@@ -137,105 +139,103 @@ public class CacheLikeNodeBytecodeEmitter implements BytecodeEmitter<CacheLikeNo
     }
 
     private String registerCache(CacheLikeNode node, BytecodeGen.Context context) {
-        // put here to ensure init order
+        // Register both delegate methods before the cache field to keep field ordinals child-first.
         String delegateSingle = context.newSingleMethodUnoptimized(node.getDelegate());
         String delegateMulti = context.newMultiMethodUnoptimized(node.getDelegate());
 
         String cacheLikeField = context.newField(IFastCacheLike.class, node.getCacheLike());
         String methodName = String.format("postProcessing_%s", cacheLikeField);
 
-        context.genPostprocessingMethod(methodName, m -> {
+        context.genPostprocessingMethod(cacheLikeField, methodName, m -> {
             Label cacheExists = new Label();
 
-            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.ifnonnull(cacheExists);
+            m.aconst(null);
+            m.areturn(InstructionAdapter.OBJECT_TYPE);
+
+            m.visitLabel(cacheExists);
+            m.load(2, InstructionAdapter.OBJECT_TYPE);
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
 
             {
-                m.load(0, InstructionAdapter.OBJECT_TYPE);
-                m.getfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
+                m.anew(Type.getType(SubCompiledDensityFunction.class));
                 m.dup();
-                m.ifnonnull(cacheExists);
-                m.pop();
-                m.pop();
-                m.areturn(Type.VOID_TYPE);
 
-                m.visitLabel(cacheExists);
-
-                {
-                    m.anew(Type.getType(SubCompiledDensityFunction.class));
-                    m.dup();
-
-                    m.load(0, InstructionAdapter.OBJECT_TYPE);
-                    m.invokedynamic(
-                            "evalSingle",
-                            Type.getMethodDescriptor(Type.getType(ISingleMethod.class), Type.getType(context.classDesc)),
-                            new Handle(
-                                    Opcodes.H_INVOKESTATIC,
-                                    "java/lang/invoke/LambdaMetafactory",
-                                    "metafactory",
-                                    "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
-                                    false
-                            ),
-                            new Object[]{
-                                    Type.getMethodType(BytecodeGen.Context.SINGLE_DESC),
-                                    new Handle(
-                                            Opcodes.H_INVOKEVIRTUAL,
-                                            context.className,
-                                            delegateSingle,
-                                            BytecodeGen.Context.SINGLE_DESC,
-                                            false
-                                    ),
-                                    Type.getMethodType(BytecodeGen.Context.SINGLE_DESC)
-                            }
-                    );
-
-                    m.load(0, InstructionAdapter.OBJECT_TYPE);
-                    m.invokedynamic(
-                            "evalMulti",
-                            Type.getMethodDescriptor(Type.getType(IMultiMethod.class), Type.getType(context.classDesc)),
-                            new Handle(
-                                    Opcodes.H_INVOKESTATIC,
-                                    "java/lang/invoke/LambdaMetafactory",
-                                    "metafactory",
-                                    "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
-                                    false
-                            ),
-                            new Object[]{
-                                    Type.getMethodType(BytecodeGen.Context.MULTI_DESC),
-                                    new Handle(
-                                            Opcodes.H_INVOKEVIRTUAL,
-                                            context.className,
-                                            delegateMulti,
-                                            BytecodeGen.Context.MULTI_DESC,
-                                            false
-                                    ),
-                                    Type.getMethodType(BytecodeGen.Context.MULTI_DESC)
-                            }
-                    );
-
-                    m.load(0, InstructionAdapter.OBJECT_TYPE);
-                    m.getfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
-                    m.checkcast(Type.getType(DensityFunction.class));
-
-                    m.invokespecial(
-                            Type.getInternalName(SubCompiledDensityFunction.class),
-                            "<init>",
-                            Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(ISingleMethod.class), Type.getType(IMultiMethod.class), Type.getType(DensityFunction.class)),
-                            false
-                    );
-
-                    m.checkcast(Type.getType(DensityFunction.class));
-                }
-
-                m.invokeinterface(
-                        Type.getInternalName(IFastCacheLike.class),
-                        "c2me$withDelegate",
-                        Type.getMethodDescriptor(Type.getType(DensityFunction.class), Type.getType(DensityFunction.class))
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.invokedynamic(
+                        "evalSingle",
+                        Type.getMethodDescriptor(Type.getType(ISingleMethod.class), Type.getType(context.classDesc)),
+                        new Handle(
+                                Opcodes.H_INVOKESTATIC,
+                                "java/lang/invoke/LambdaMetafactory",
+                                "metafactory",
+                                "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                                false
+                        ),
+                        new Object[]{
+                                Type.getMethodType(BytecodeGen.Context.SINGLE_DESC),
+                                new Handle(
+                                        Opcodes.H_INVOKEVIRTUAL,
+                                        context.className,
+                                        delegateSingle,
+                                        BytecodeGen.Context.SINGLE_DESC,
+                                        false
+                                ),
+                                Type.getMethodType(BytecodeGen.Context.SINGLE_DESC)
+                        }
                 );
+
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.invokedynamic(
+                        "evalMulti",
+                        Type.getMethodDescriptor(Type.getType(IMultiMethod.class), Type.getType(context.classDesc)),
+                        new Handle(
+                                Opcodes.H_INVOKESTATIC,
+                                "java/lang/invoke/LambdaMetafactory",
+                                "metafactory",
+                                "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                                false
+                        ),
+                        new Object[]{
+                                Type.getMethodType(BytecodeGen.Context.MULTI_DESC),
+                                new Handle(
+                                        Opcodes.H_INVOKEVIRTUAL,
+                                        context.className,
+                                        delegateMulti,
+                                        BytecodeGen.Context.MULTI_DESC,
+                                        false
+                                ),
+                                Type.getMethodType(BytecodeGen.Context.MULTI_DESC)
+                        }
+                );
+
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.checkcast(Type.getType(DensityFunction.class));
+
+                m.invokespecial(
+                        Type.getInternalName(SubCompiledDensityFunction.class),
+                        "<init>",
+                        Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(ISingleMethod.class), Type.getType(IMultiMethod.class), Type.getType(DensityFunction.class)),
+                        false
+                );
+
+                m.checkcast(Type.getType(DensityFunction.class));
             }
 
-            m.putfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
+            m.invokeinterface(
+                    Type.getInternalName(IFastCacheLike.class),
+                    "c2me$withDelegate",
+                    Type.getMethodDescriptor(Type.getType(DensityFunction.class), Type.getType(DensityFunction.class))
+            );
+            m.invokeinterface(
+                    Type.getInternalName(Function.class),
+                    "apply",
+                    Type.getMethodDescriptor(InstructionAdapter.OBJECT_TYPE, InstructionAdapter.OBJECT_TYPE)
+            );
+            m.checkcast(Type.getType(IFastCacheLike.class));
 
-            m.areturn(Type.VOID_TYPE);
+            m.areturn(InstructionAdapter.OBJECT_TYPE);
         });
         return cacheLikeField;
     }

--- a/c2me-opts-dfc/src/test/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGenCacheInitializationTest.java
+++ b/c2me-opts-dfc/src/test/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGenCacheInitializationTest.java
@@ -1,0 +1,190 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CacheLikeNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.ast.opto.OptoPasses;
+import com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike;
+import net.minecraft.Bootstrap;
+import net.minecraft.SharedConstants;
+import net.minecraft.util.dynamic.CodecHolder;
+import net.minecraft.world.gen.densityfunction.DensityFunction;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BytecodeGenCacheInitializationTest {
+
+    private static final DensityFunction.NoisePos ORIGIN = new TestNoisePos(0, 0, 0);
+
+    @BeforeAll
+    public static void bootstrap() {
+        SharedConstants.createGameVersion();
+        Bootstrap.initialize();
+    }
+
+    @Test
+    public void materializesCacheFieldsChildFirstDuringConstruction() {
+        TestCache innerCache = new TestCache("inner", null, false);
+        TestCache outerCache = new TestCache("outer", null, false);
+        CacheLikeNode inner = new CacheLikeNode(innerCache, new ConstantNode(1.0));
+        CacheLikeNode outer = new CacheLikeNode(outerCache, inner);
+
+        CompiledEntry entry = BytecodeGen.compile0("cache_init_order", OptoPasses.AstPair.ofOptimizedOnly(outer));
+        List<String> materializationOrder = new ArrayList<>();
+        CompiledEntry transformed = entry.newInstance(entry.getArgs(), cacheLike -> {
+            TestCache cache = (TestCache) cacheLike;
+            materializationOrder.add(cache.name);
+            if (cache.name.equals("outer")) {
+                assertEquals(42.0, cache.delegate.sample(ORIGIN));
+            }
+            return cache.materialized();
+        });
+
+        assertEquals(List.of("inner", "outer"), materializationOrder);
+        assertTrue(((TestCache) transformed.getArgs()[0]).materialized);
+        for (java.lang.reflect.Field field : entry.getClass().getDeclaredFields()) {
+            assertTrue(Modifier.isFinal(field.getModifiers()), field::toString);
+        }
+    }
+
+    @Test
+    public void skipsTransformerForRemovedCache() {
+        TestCache innerCache = new TestCache("inner", null, false);
+        TestCache outerCache = new TestCache("outer", null, false);
+        CacheLikeNode inner = new CacheLikeNode(innerCache, new ConstantNode(1.0));
+        CacheLikeNode outer = new CacheLikeNode(outerCache, inner);
+        CompiledEntry entry = BytecodeGen.compile0("removed_cache", OptoPasses.AstPair.ofOptimizedOnly(outer));
+        Object[] args = entry.getArgs();
+        args[0] = null;
+        AtomicInteger transformations = new AtomicInteger();
+
+        CompiledEntry transformed = entry.newInstance(args, cacheLike -> {
+            transformations.incrementAndGet();
+            return cacheLike;
+        });
+
+        assertNull(transformed.getArgs()[0]);
+        assertEquals(1, transformations.get());
+    }
+
+    private static final class TestCache implements IFastCacheLike {
+
+        private final String name;
+        private final DensityFunction delegate;
+        private final boolean materialized;
+
+        private TestCache(String name, DensityFunction delegate, boolean materialized) {
+            this.name = name;
+            this.delegate = delegate;
+            this.materialized = materialized;
+        }
+
+        private TestCache materialized() {
+            return new TestCache(this.name, this.delegate, true);
+        }
+
+        @Override
+        public double sample(NoisePos pos) {
+            return this.delegate.sample(pos);
+        }
+
+        @Override
+        public void fill(double[] densities, EachApplier applier) {
+            this.delegate.fill(densities, applier);
+        }
+
+        @Override
+        public DensityFunction applyInternal(DensityFunctionVisitor visitor) {
+            return visitor.apply(this);
+        }
+
+        @Override
+        public double minValue() {
+            return Double.NEGATIVE_INFINITY;
+        }
+
+        @Override
+        public double maxValue() {
+            return Double.POSITIVE_INFINITY;
+        }
+
+        @Override
+        public CodecHolder<? extends DensityFunction> getCodecHolder() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public double c2me$getCached(int x, int y, int z, EvalType evalType) {
+            return this.materialized ? 42.0 : Double.longBitsToDouble(CACHE_MISS_NAN_BITS);
+        }
+
+        @Override
+        public boolean c2me$getCached(double[] res, int[] x, int[] y, int[] z, EvalType evalType) {
+            return false;
+        }
+
+        @Override
+        public void c2me$cache(int x, int y, int z, EvalType evalType, double cached) {
+        }
+
+        @Override
+        public void c2me$cache(double[] res, int[] x, int[] y, int[] z, EvalType evalType) {
+        }
+
+        @Override
+        public boolean c2me$isActualCache() {
+            return this.materialized;
+        }
+
+        @Override
+        public String c2me$describeCacheLike() {
+            return this.name;
+        }
+
+        @Override
+        public DensityFunction c2me$getDelegate() {
+            return this.delegate;
+        }
+
+        @Override
+        public DensityFunction c2me$withDelegate(DensityFunction delegate) {
+            return new TestCache(this.name, delegate, this.materialized);
+        }
+    }
+
+    private record TestNoisePos(int blockX, int blockY, int blockZ) implements DensityFunction.NoisePos {
+    }
+}


### PR DESCRIPTION
## Summary

- Register DFC cache dependencies before their parent cache fields.
- Materialize cache wrappers while constructing generated entries in dependency order.
- Add regression coverage for nested eager cache materialization and removed caches.

## Problem

Some cache wrappers, notably `ChunkNoiseSampler.FlatCache`, eagerly sample their
delegate when materialized. Previously, parent caches could observe an entry
whose child cache fields still referenced unmaterialized wrappers, causing the
compiled density graph to be evaluated repeatedly during FlatCache prefill.

## Implementation

Generated entry constructors now accept a cache transformation function. Cache
wrappers are rebound to the entry under construction, transformed child-first,
and assigned directly to their final fields to ensure eager parent cache
initialization sees already-materialized child caches.

## Testing

- Added generated-bytecode regression tests covering nested cache initialization,
  constructor-time delegate evaluation, removed caches, and final field flags.