### PR TITLE
Fill float for constant F32 multi delegates

### DIFF
--- a/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGen.java
+++ b/c2me-opts-dfc/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGen.java
@@ -754,7 +754,7 @@ public class BytecodeGen {
                     }
                     case ValuesMethodDefF32 f32 -> {
                         m.fconst(f32.constValue());
-                        m.invokestatic(Type.getInternalName(Arrays.class), "fill", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class), Type.DOUBLE_TYPE), false);
+                        m.invokestatic(Type.getInternalName(Arrays.class), "fill", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(float[].class), Type.FLOAT_TYPE), false);
                     }
                     default -> throw new IllegalStateException("Unexpected type: " + target.getClass().getName());
                 }


### PR DESCRIPTION
`BytecodeGen.Context#callDelegateMulti` emits the constant ValuesMethodDefF32 branch with a float[] receiver and a float value, but describes the invocation as `Arrays.fill(double[], double)`.

As the operand stack does not match the method descriptor and the generated class will fail bytecode verification if the code enters the F32 branch.

I checked for the possible control flows that could enter the branch and found no results. This looks more like a future-proof fix.